### PR TITLE
Support for animating in/out embedded maps on iOS (experimental)

### DIFF
--- a/src/ios/GoogleMaps/GoogleMapsViewController.h
+++ b/src/ios/GoogleMaps/GoogleMapsViewController.h
@@ -31,7 +31,7 @@
 - (GMSPolyline *)getPolylineByKey: (NSString *)key;
 - (GMSTileLayer *)getTileLayerByKey: (NSString *)key;
 - (GMSGroundOverlay *)getGroundOverlayByKey: (NSString *)key;
-- (void)updateMapViewLayout;
+- (void)updateMapViewLayout: (BOOL)animated;
 
 - (void)removeObjectForKey: (NSString *)key;
 @end

--- a/src/ios/GoogleMaps/GoogleMapsViewController.m
+++ b/src/ios/GoogleMaps/GoogleMapsViewController.m
@@ -26,15 +26,21 @@ NSDictionary *initOptions;
 
 - (void)loadView {
   [super loadView];
-  [self updateMapViewLayout];
+  [self updateMapViewLayout:NO];
   
 }
-- (void)updateMapViewLayout {
+- (void)updateMapViewLayout:(BOOL) animated {
   
   if (self.isFullScreen == NO) {
-    self.view.hidden = YES;
-    [self.view setFrameWithDictionary:self.embedRect];
-    self.view.hidden = NO;
+    if (animated == NO) {
+      self.view.hidden = YES;
+      [self.view setFrameWithDictionary:self.embedRect];
+      self.view.hidden = NO;
+    } else {
+      [UIView animateWithDuration:0.5f animations:^{
+        [self.view setFrameWithDictionary:self.embedRect];
+      }];
+    }
   }
 }
 

--- a/www/googlemaps-cdv-plugin.js
+++ b/www/googlemaps-cdv-plugin.js
@@ -409,8 +409,8 @@
   };
   
   
-  App.prototype.refreshLayout = function() {
-    onMapResize();
+  App.prototype.refreshLayout = function(animated) {
+    onMapResize(undefined, animated);
   };
   
   App.prototype.toDataURL = function(callback) {
@@ -1399,7 +1399,7 @@
     
     return divSize;
   }
-  function onMapResize() {
+  function onMapResize(event, animated) {
     var self = window.plugin.google.maps.Map;
     var div = self.get("div");
     if (!div) {
@@ -1410,7 +1410,7 @@
       cordova.exec(null, self.errorHandler, PLUGIN_NAME, 'setDiv', []);
     } else {
       var divSize = getDivSize(div);
-      cordova.exec(null, self.errorHandler, PLUGIN_NAME, 'resizeMap', [divSize]);
+      cordova.exec(null, self.errorHandler, PLUGIN_NAME, 'resizeMap', [divSize, animated]);
     }
     
   }


### PR DESCRIPTION
Experimental support for animating views, as per issue #50

googlemaps-cdv-plugin.js
Map.refreshLayout method now supports an "animated" flag
this gets passed through to onMapResize, which passes it through as an argument to native resizeMap

GoogleMapsViewController.m (and .h)
updateMapViewLayout method now has an "animated" argument
if animated is on then frame adjustments get animated
animation duration is currently hard-coded to 0.5s
- this should probably be a config option

GoogleMaps.m
all calls to updateMapViewLayout now include an animated argument
resizeMap method passes through animated flag
added bonus - _removeMapView and closeDialog method now non-functional for embedded maps
