### PR TITLE
Fixes blank screen issue with crosswalk

### DIFF
--- a/src/android/plugin/google/maps/MyPluginLayout.java
+++ b/src/android/plugin/google/maps/MyPluginLayout.java
@@ -1,5 +1,6 @@
 package plugin.google.maps;
 
+import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -51,7 +52,6 @@ public class MyPluginLayout extends FrameLayout  {
     this.view = view;
     this.root = (ViewGroup) view.getParent();
     this.context = view.getContext();
-    view.setBackgroundColor(Color.TRANSPARENT);
     if (VERSION.SDK_INT >= 21 || "org.xwalk.core.XWalkView".equals(view.getClass().getName())) {
       view.setLayerType(View.LAYER_TYPE_HARDWARE, null);
     }
@@ -193,6 +193,18 @@ public class MyPluginLayout extends FrameLayout  {
   }
   
   public void attachMyView(ViewGroup pluginView) {
+    view.setBackgroundColor(Color.TRANSPARENT);
+    if("org.xwalk.core.XWalkView".equals(view.getClass().getName())
+        || "org.crosswalk.engine.XWalkCordovaView".equals(view.getClass().getName())) {
+      try {
+        /* view.setZOrderOnTop(true)
+         * Called just in time as with root.setBackground(...) the color
+         * come in front and take the whoel screen */
+        view.getClass().getMethod("setZOrderOnTop", boolean.class)
+          .invoke(view, true);
+      }
+      catch(Exception e) {}
+    }
     scrollView.setHorizontalScrollBarEnabled(false);
     scrollView.setVerticalScrollBarEnabled(false);
     


### PR DESCRIPTION
For issue #638. Same PR as #778 but way more simple.
The white screen is due to running ```root.setBackgroundColor(Color.WHITE)``` and ```view.setZOrderOnTop(true)``` (modification for crosswalk). The setZOrderOnTop cause the root to come first until refreshed by pulling the view from it.
The setZOrderOnTop must be called only when the map is added, so it should **not** be added to XWalkWebViewEngine.java. The Transluced theme seems not necessary to as it cause the app to be fully transparent when the map is inserted.

What i tried :
- map creation at startup (on deviceready) then hide splashscreen on map ready or even later
- no map at startup. Then getMap(...) called later manually
- reduce the app and reopen id
- close the app with back button and reopen it
- kill the app and reopen it
- navigator.app.exitApp() and reopen it

What i have not tried : ideas are welcome ;)

Tested with and without crosswalk using cordova 5.3.3 and 5.4.1 with these pugins
```
cordova-plugin-crosswalk-webview 1.4.0 "Crosswalk WebView Engine"
cordova-plugin-device 1.1.0 "Device"
cordova-plugin-splashscreen 3.0.0 "Splashscreen"
cordova-plugin-whitelist 1.2.0 "Whitelist"
plugin.google.maps 1.3.8 "phonegap-googlemaps-plugin"
```