### PR TITLE
Add tappable/clickable options to ground-overlay, polygon and polyline

### DIFF
--- a/src/android/plugin/google/maps/AsyncKmlParser.java
+++ b/src/android/plugin/google/maps/AsyncKmlParser.java
@@ -26,6 +26,7 @@ import android.os.AsyncTask;
 import android.os.Bundle;
 import android.util.Log;
 
+@SuppressWarnings("deprecation")
 public class AsyncKmlParser extends AsyncTask<String, Void, Bundle> {
   private XmlPullParser parser;
   private GoogleMaps mMapCtrl;

--- a/src/android/plugin/google/maps/GoogleMaps.java
+++ b/src/android/plugin/google/maps/GoogleMaps.java
@@ -102,9 +102,9 @@ public class GoogleMaps extends CordovaPlugin implements View.OnClickListener, O
   private float density;
   private HashMap<String, Bundle> bufferForLocationDialog = new HashMap<String, Bundle>();
   
-  private enum EVENTS {
+  /*private enum EVENTS {
     onScrollChanged
-  }
+  }*/
   private enum TEXT_STYLE_ALIGNMENTS {
     left, center, right
   }

--- a/src/android/plugin/google/maps/PluginGroundOverlay.java
+++ b/src/android/plugin/google/maps/PluginGroundOverlay.java
@@ -55,6 +55,9 @@ public class PluginGroundOverlay extends MyPlugin {
     if (opts.has("visible")) {
       options.visible(opts.getBoolean("visible"));
     }
+    if (opts.has("clickable")) {
+      options.clickable(opts.getBoolean("clickable"));
+    }
 
     if (opts.has("bounds") == true) {
       JSONArray points = opts.getJSONArray("bounds");

--- a/src/android/plugin/google/maps/PluginGroundOverlay.java
+++ b/src/android/plugin/google/maps/PluginGroundOverlay.java
@@ -13,6 +13,7 @@ import org.json.JSONObject;
 import android.content.res.AssetManager;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.util.Base64;
 
 import com.google.android.gms.maps.model.BitmapDescriptor;
 import com.google.android.gms.maps.model.BitmapDescriptorFactory;
@@ -97,6 +98,26 @@ public class PluginGroundOverlay extends MyPlugin {
     }
 
     String filePath = url;
+
+    //=================================
+    // Load the image from the data uri 
+    //=================================
+    if (filePath.indexOf("data") == 0) {
+      filePath = filePath.replace("data:image/png;base64,","");
+      Bitmap image = null;
+      byte[] decodedString = Base64.decode(filePath.getBytes(), Base64.DEFAULT);
+      image = BitmapFactory.decodeByteArray(decodedString,0,decodedString.length);
+      BitmapDescriptor bitmapDescriptor = BitmapDescriptorFactory.fromBitmap(image);
+      if (bitmapDescriptor != null) {
+        options.image(bitmapDescriptor);
+        GroundOverlay groundOverlay = PluginGroundOverlay.this.map.addGroundOverlay(options);
+        callback.onPostExecute(groundOverlay);
+      } else {
+        callback.onError("Can not load image from " + url);
+      }
+      return;
+    }
+
     if (filePath.indexOf("://") == -1 && 
         filePath.startsWith("/") == false && 
         filePath.startsWith("www/") == false) {

--- a/src/android/plugin/google/maps/PluginPolygon.java
+++ b/src/android/plugin/google/maps/PluginPolygon.java
@@ -50,6 +50,9 @@ public class PluginPolygon extends MyPlugin implements MyPluginInterface  {
         if (opts.has("visible")) {
             polygonOptions.visible(opts.getBoolean("visible"));
         }
+        if (opts.has("clickable")) {
+            polygonOptions.visible(opts.getBoolean("clickable"));
+        }
         if (opts.has("geodesic")) {
             polygonOptions.geodesic(opts.getBoolean("geodesic"));
         }

--- a/src/android/plugin/google/maps/PluginPolyline.java
+++ b/src/android/plugin/google/maps/PluginPolyline.java
@@ -54,7 +54,10 @@ public class PluginPolyline extends MyPlugin implements MyPluginInterface  {
     if (opts.has("zIndex")) {
       polylineOptions.zIndex(opts.getInt("zIndex"));
     }
-    
+    if (opts.has("clickable")) {
+      polylineOptions.clickable(opts.getBoolean("clickable"));
+    }
+
     Polyline polyline = map.addPolyline(polylineOptions);
     String id = "polyline_" + polyline.getId();
     this.objects.put(id, polyline);

--- a/src/ios/GoogleMaps/GoogleMapsViewController.h
+++ b/src/ios/GoogleMaps/GoogleMapsViewController.h
@@ -22,6 +22,7 @@
 @property (nonatomic) NSDictionary *embedRect;
 @property (nonatomic) CGRect screenSize;
 @property (nonatomic) BOOL debuggable;
+@property (nonatomic) CLLocationCoordinate2D lastTapCoordinate;
 
 
 //- (UIView *)mapView:(GMSMapView *)mapView markerInfoWindow:(GMSMarker *)marker;

--- a/src/ios/GoogleMaps/GoogleMapsViewController.m
+++ b/src/ios/GoogleMaps/GoogleMapsViewController.m
@@ -164,6 +164,17 @@ NSDictionary *initOptions;
     }
   
     [self.view addSubview: self.map];
+
+    // Attach an additional click handler
+    for(UIGestureRecognizer *g in self.map.gestureRecognizers){
+        [g addTarget:self action:@selector(tapTouchTap:)];
+    }
+}
+
+- (void)tapTouchTap:(UITapGestureRecognizer*)touchGesture
+{
+    CGPoint point = [touchGesture locationInView:self.view];
+    self.lastTapCoordinate = [self.map.projection coordinateForPoint:point];
 }
 
 
@@ -284,7 +295,7 @@ NSDictionary *initOptions;
       [overlayClass isEqualToString:@"GMSPolyline"] ||
       [overlayClass isEqualToString:@"GMSCircle"] ||
       [overlayClass isEqualToString:@"GMSGroundOverlay"]) {
-    [self triggerOverlayEvent:@"overlay_click" id:overlay.title];
+    [self triggerOverlayEvent:@"overlay_click" id:overlay.title coordinate:self.lastTapCoordinate];
   }
 }
 
@@ -336,10 +347,9 @@ NSDictionary *initOptions;
 /**
  * Involve App._onOverlayEvent
  */
-- (void)triggerOverlayEvent: (NSString *)eventName id:(NSString *) id
+- (void)triggerOverlayEvent: (NSString *)eventName id:(NSString *) id coordinate:(CLLocationCoordinate2D) coordinate
 {
-  NSString* jsString = [NSString stringWithFormat:@"plugin.google.maps.Map._onOverlayEvent('%@', '%@');",
-                                      eventName, id];
+  NSString* jsString = [NSString stringWithFormat:@"plugin.google.maps.Map._onOverlayEvent('%@', '%@', new window.plugin.google.maps.LatLng(%f,%f));",eventName, id, coordinate.latitude, coordinate.longitude];
   [self.webView stringByEvaluatingJavaScriptFromString:jsString];
 }
 

--- a/src/ios/GoogleMaps/GoogleMapsViewController.m
+++ b/src/ios/GoogleMaps/GoogleMapsViewController.m
@@ -100,6 +100,10 @@ NSDictionary *initOptions;
       if ([controls valueForKey:@"myLocationButton"] != nil) {
         isEnabled = [[controls valueForKey:@"myLocationButton"] boolValue];
         self.map.settings.myLocationButton = isEnabled;
+      }
+      //myLocationEnabled
+      if ([controls valueForKey:@"myLocationEnabled"] != nil) {
+        isEnabled = [[controls valueForKey:@"myLocationEnabled"] boolValue];
         self.map.myLocationEnabled = isEnabled;
       }
       //indoorPicker

--- a/src/ios/GoogleMaps/GroundOverlay.h
+++ b/src/ios/GoogleMaps/GroundOverlay.h
@@ -9,6 +9,7 @@
 #import "GoogleMaps.h"
 #import "MyPlgunProtocol.h"
 #import "PluginUtil.h"
+#import "NSData+Base64.h"
 
 @interface GroundOverlay : CDVPlugin<MyPlgunProtocol>
 

--- a/src/ios/GoogleMaps/GroundOverlay.m
+++ b/src/ios/GoogleMaps/GroundOverlay.m
@@ -83,7 +83,19 @@
   NSString *id = [NSString stringWithFormat:@"groundOverlay_icon_%lu", (unsigned long)layer.hash];
   
   NSError *error;
-  NSRange range = [urlStr rangeOfString:@"://"];
+
+  // First check for base64
+  NSRange range = [urlStr rangeOfString:@"base64,"];
+  if(range.location != NSNotFound) {
+    int chop = range.location + range.length;
+    NSData *data = [[NSData alloc]initWithBase64EncodedString:[urlStr substringFromIndex:chop] options:NSDataBase64DecodingIgnoreUnknownCharacters];
+    layer.icon = [UIImage imageWithData:data];
+    [self.mapCtrl.overlayManager setObject:layer.icon forKey: id];
+    completionHandler(nil);
+    return;
+  }
+
+  range = [urlStr rangeOfString:@"://"];
   if (range.location == NSNotFound) {
     range = [urlStr rangeOfString:@"www/"];
     if (range.location == NSNotFound) {

--- a/src/ios/GoogleMaps/GroundOverlay.m
+++ b/src/ios/GoogleMaps/GroundOverlay.m
@@ -132,6 +132,10 @@
   NSURL *isUrl = [NSURL URLWithString:urlStr];
   if (!isUrl || !isUrl.scheme || isUrl.host) {
     layer.icon = [UIImage imageNamed:urlStr];
+  
+  //range = [urlStr rangeOfString:@"http://"];
+  //if (range.location == NSNotFound) {
+  //  layer.icon = [UIImage imageWithContentsOfFile:urlStr];
     [self.mapCtrl.overlayManager setObject:layer.icon forKey: id];
     completionHandler(nil);
   } else {

--- a/src/ios/GoogleMaps/GroundOverlay.m
+++ b/src/ios/GoogleMaps/GroundOverlay.m
@@ -56,7 +56,7 @@
             layer.bearing = [[json valueForKey:@"bearing"] floatValue];
         }
 
-        layer.tappable = YES;
+        layer.tappable = [[json valueForKey:@"clickable"] boolValue];
 
         NSString *id = [NSString stringWithFormat:@"groundOverlay_%lu", (unsigned long)layer.hash];
         [self_.mapCtrl.overlayManager setObject:layer forKey: id];

--- a/src/ios/GoogleMaps/Map.m
+++ b/src/ios/GoogleMaps/Map.m
@@ -379,9 +379,16 @@
       isEnabled = [[controls valueForKey:@"myLocationButton"] boolValue];
       if (isEnabled == true) {
         self.mapCtrl.map.settings.myLocationButton = YES;
-        self.mapCtrl.map.myLocationEnabled = YES;
       } else {
         self.mapCtrl.map.settings.myLocationButton = NO;
+      }
+    }
+    //myLocationEnabled
+    if ([controls valueForKey:@"myLocationEnabled"] != nil) {
+      isEnabled = [[controls valueForKey:@"myLocationEnabled"] boolValue];
+      if (isEnabled == true) {
+        self.mapCtrl.map.myLocationEnabled = YES;
+      } else {
         self.mapCtrl.map.myLocationEnabled = NO;
       }
     }

--- a/src/ios/GoogleMaps/Polygon.m
+++ b/src/ios/GoogleMaps/Polygon.m
@@ -47,8 +47,8 @@
 
   polygon.strokeWidth = [[json valueForKey:@"strokeWidth"] floatValue];
   polygon.zIndex = [[json valueForKey:@"zIndex"] floatValue];
-    
-  polygon.tappable = YES;
+
+  polygon.tappable = [[json valueForKey:@"clickable"] boolValue]
 
   NSString *id = [NSString stringWithFormat:@"polygon_%lu", (unsigned long)polygon.hash];
   [self.mapCtrl.overlayManager setObject:polygon forKey: id];

--- a/src/ios/GoogleMaps/Polyline.m
+++ b/src/ios/GoogleMaps/Polyline.m
@@ -43,8 +43,8 @@
   polyline.strokeWidth = [[json valueForKey:@"width"] floatValue];
   polyline.zIndex = [[json valueForKey:@"zIndex"] floatValue];
 
-  polyline.tappable = YES;
-  
+  polyline.tappable = [[json valueForKey:@"clickable"] boolValue];
+
   NSString *id = [NSString stringWithFormat:@"polyline_%lu", (unsigned long)polyline.hash];
   [self.mapCtrl.overlayManager setObject:polyline forKey: id];
   polyline.title = id;

--- a/www/googlemaps-cdv-plugin.js
+++ b/www/googlemaps-cdv-plugin.js
@@ -1060,6 +1060,7 @@ App.prototype.addPolyline = function(polylineOptions, callback) {
     polylineOptions.color = HTMLColor2RGBA(polylineOptions.color || "#FF000080", 0.75);
     polylineOptions.width = polylineOptions.width || 10;
     polylineOptions.visible = polylineOptions.visible === undefined ? true : polylineOptions.visible;
+    polylineOptions.clickable = polylineOptions.clickable === undefined ? true : polylineOptions.clickable;
     polylineOptions.zIndex = polylineOptions.zIndex || 4;
     polylineOptions.geodesic = polylineOptions.geodesic || false;
 
@@ -1086,6 +1087,7 @@ App.prototype.addPolygon = function(polygonOptions, callback) {
     }
     polygonOptions.strokeWidth = polygonOptions.strokeWidth || 10;
     polygonOptions.visible = polygonOptions.visible === undefined ? true : polygonOptions.visible;
+    polygonOptions.clickable = polygonOptions.clickable === undefined ? true : polygonOptions.clickable;
     polygonOptions.zIndex = polygonOptions.zIndex || 2;
     polygonOptions.geodesic = polygonOptions.geodesic || false;
     polygonOptions.addHole = polygonOptions.addHole || [];
@@ -1138,6 +1140,7 @@ App.prototype.addGroundOverlay = function(groundOverlayOptions, callback) {
     groundOverlayOptions = groundOverlayOptions || {};
     groundOverlayOptions.url = groundOverlayOptions.url || null;
     groundOverlayOptions.visible = groundOverlayOptions.visible === undefined ? true : groundOverlayOptions.visible;
+    groundOverlayOptions.clickable = groundOverlayOptions.clickable === undefined ? true : groundOverlayOptions.clickable;
     groundOverlayOptions.zIndex = groundOverlayOptions.zIndex || 1;
     groundOverlayOptions.bounds = groundOverlayOptions.bounds || [];
 


### PR DESCRIPTION
I needed to be able to create a ground overlay that wasn't tappable (as there was a polygon underneath it). So this change adds a "clickable" option to addGroundOverlay, addPolygon and addPolyline which sets the appropriate option (ios=tappable, android=clickable).