### PR TITLE
Fixing bug that add ./ and then the url to the icon value when is passed a base64 image

### DIFF
--- a/src/android/plugin/google/maps/AsyncLoadImage.java
+++ b/src/android/plugin/google/maps/AsyncLoadImage.java
@@ -91,8 +91,8 @@ public class AsyncLoadImage extends AsyncTask<String, Void, Bitmap> {
       
       // Resize
       float density = Resources.getSystem().getDisplayMetrics().density;
-      int newWidth = (int)(mWidth * 1); // density);
-      int newHeight = (int)(mHeight * 1); // density);
+      int newWidth = (int)(mWidth * density);
+      int newHeight = (int)(mHeight * density);
 
       
       /**

--- a/src/android/plugin/google/maps/AsyncLoadImage.java
+++ b/src/android/plugin/google/maps/AsyncLoadImage.java
@@ -91,8 +91,8 @@ public class AsyncLoadImage extends AsyncTask<String, Void, Bitmap> {
       
       // Resize
       float density = Resources.getSystem().getDisplayMetrics().density;
-      int newWidth = (int)(mWidth * density);
-      int newHeight = (int)(mHeight * density);
+      int newWidth = (int)(mWidth * 1); // density);
+      int newHeight = (int)(mHeight * 1); // density);
 
       
       /**

--- a/src/android/plugin/google/maps/PluginMarker.java
+++ b/src/android/plugin/google/maps/PluginMarker.java
@@ -834,6 +834,7 @@ public class PluginMarker extends MyPlugin {
     }
     
     if (iconUrl.indexOf("http") == 0) {
+      Log.e("GoogleMaps", "making bitmap from http");
       int width = -1;
       int height = -1;
       if (iconProperty.containsKey("size") == true) {

--- a/src/android/plugin/google/maps/PluginMarker.java
+++ b/src/android/plugin/google/maps/PluginMarker.java
@@ -671,12 +671,12 @@ public class PluginMarker extends MyPlugin {
         @Override
         public void onError(String errorMsg) {
           callbackContext.error(errorMsg);
-          Log.e("TAG2", "Exception: ", e);
         }
       });
       
       } catch (Exception e) {
         e.printStackTrace();
+        Log.e("TAG2", "Exception: ", e);
       }
       
     } else {
@@ -716,6 +716,9 @@ public class PluginMarker extends MyPlugin {
 
         @Override
         protected Bitmap doInBackground(Void... params) {
+          
+          try {
+          
           String iconUrl = iconProperty.getString("url");
           
           Bitmap image = null;
@@ -783,6 +786,11 @@ public class PluginMarker extends MyPlugin {
             image = PluginUtil.scaleBitmapForDevice(image);
           }
           return image;
+        
+          } catch (Exception e) { // FIXME
+              e.printStackTrace();
+              Log.e("TAG3", "Exception: ", e);
+          }
         }
         
         @Override

--- a/src/android/plugin/google/maps/PluginMarker.java
+++ b/src/android/plugin/google/maps/PluginMarker.java
@@ -716,6 +716,7 @@ public class PluginMarker extends MyPlugin {
           if (iconUrl.indexOf("data:image/") == 0 && iconUrl.indexOf(";base64,") > -1) {
             String[] tmp = iconUrl.split(",");
             image = PluginUtil.getBitmapFromBase64encodedImage(tmp[1]);
+            Log.w("GoogleMaps", "bitmap from base64 (" + (image != null ? "sucess" : "fail"));
           } else if (iconUrl.indexOf("file://") == 0 &&
               iconUrl.indexOf("file:///android_asset/") == -1) {
             iconUrl = iconUrl.replace("file://", "");

--- a/src/android/plugin/google/maps/PluginMarker.java
+++ b/src/android/plugin/google/maps/PluginMarker.java
@@ -160,18 +160,16 @@ public class PluginMarker extends MyPlugin {
         @Override
         public void onPostExecute(Object object) {
           Marker marker = (Marker)object;
-          if (opts.has("visible")) {
-            try {
+          try {
+            if (opts.has("visible")) {
               marker.setVisible(opts.getBoolean("visible"));
-            } catch (Exception e) {
-              e.printStackTrace();
-              Log.e("XXX", "Exception: ", e);
+            } else {
+              marker.setVisible(true);
             }
-          } else {
-            marker.setVisible(true);
+          } catch (Exception e) {
+            e.printStackTrace();
+            Log.e("XXX", "Exception: ", e);
           }
-          
-
           // Animation
           String markerAnimation = null;
           if (opts.has("animation")) {
@@ -777,7 +775,7 @@ public class PluginMarker extends MyPlugin {
         
           } catch (Exception e) { // FIXME
               e.printStackTrace();
-              Log.e("TAG3", "Exception: ", e);
+              Log.e("XXX3", "Exception: ", e);
               return null;
           }
         }

--- a/src/android/plugin/google/maps/PluginMarker.java
+++ b/src/android/plugin/google/maps/PluginMarker.java
@@ -687,7 +687,8 @@ public class PluginMarker extends MyPlugin {
     
     if (iconUrl.indexOf("://") == -1 && 
         iconUrl.startsWith("/") == false && 
-        iconUrl.startsWith("www/") == false) {
+        iconUrl.startsWith("www/") == false &&
+        iconUrl.startsWith("data:image") == false) {
       iconUrl = "./" + iconUrl;
     }
     if (iconUrl.indexOf("./") == 0) {
@@ -697,11 +698,14 @@ public class PluginMarker extends MyPlugin {
     }
     
     if (iconUrl == null) {
-      callback.onPostExecute(marker);
-      return;
+    	Log.i("GoogleMaps", "icon is null (" + iconUrl + ")");
+      	callback.onPostExecute(marker);
+      	return;
     }
     
     if (iconUrl.indexOf("http") != 0) {
+      
+      Log.i("GoogleMaps", "icon is not http (" + iconUrl + ")");
       
       AsyncTask<Void, Void, Bitmap> task = new AsyncTask<Void, Void, Bitmap>() {
 
@@ -837,7 +841,9 @@ public class PluginMarker extends MyPlugin {
     }
     
     if (iconUrl.indexOf("http") == 0) {
-      Log.e("GoogleMaps", "making bitmap from http");
+    	
+      Log.i("GoogleMaps", "icon is http (" + iconUrl + ")");
+      
       int width = -1;
       int height = -1;
       if (iconProperty.containsKey("size") == true) {

--- a/src/android/plugin/google/maps/PluginMarker.java
+++ b/src/android/plugin/google/maps/PluginMarker.java
@@ -695,6 +695,8 @@ public class PluginMarker extends MyPlugin {
       return;
     }
     
+    Log.e("XXXX", "XXX bitmap base64 " + iconUrl);
+    Log.w("XXXX", "XXX bitmap base64 " + iconUrl);
     
     if (iconUrl.indexOf("http") != 0) {
       

--- a/src/android/plugin/google/maps/PluginMarker.java
+++ b/src/android/plugin/google/maps/PluginMarker.java
@@ -51,11 +51,6 @@ public class PluginMarker extends MyPlugin {
     // Create an instance of Marker class
     final MarkerOptions markerOptions = new MarkerOptions();
     final JSONObject opts = args.getJSONObject(1);
-	
-    if (PluginMarker.this.mapCtrl.isDebug) {
-    	Log.d("GoogleMaps", "Creating marker (" + opts.toString() + ")");
-    }
-	
     if (opts.has("position")) {
         JSONObject position = opts.getJSONObject("position");
         markerOptions.position(new LatLng(position.getDouble("lat"), position.getDouble("lng")));
@@ -159,22 +154,20 @@ public class PluginMarker extends MyPlugin {
       if (opts.has("animation")) {
         bundle.putString("animation", opts.getString("animation"));
       }
-      
       this.setIcon_(marker, bundle, new PluginAsyncInterface() {
 
         @Override
         public void onPostExecute(Object object) {
           Marker marker = (Marker)object;
-          try {
-            if (opts.has("visible")) {
+          if (opts.has("visible")) {
+            try {
               marker.setVisible(opts.getBoolean("visible"));
-            } else {
-              marker.setVisible(true);
-            }
-          } catch (Exception e) {
-            e.printStackTrace();
-            Log.e("GoogleMaps", "Exception setting visible", e);
+            } catch (JSONException e) {}
+          } else {
+            marker.setVisible(true);
           }
+          
+
           // Animation
           String markerAnimation = null;
           if (opts.has("animation")) {
@@ -657,7 +650,6 @@ public class PluginMarker extends MyPlugin {
       bundle.putString("url", (String)value);
     }
     if (bundle != null) {
-      
       this.setIcon_(marker, bundle, new PluginAsyncInterface() {
 
         @Override
@@ -684,11 +676,6 @@ public class PluginMarker extends MyPlugin {
     }
     
     String iconUrl = iconProperty.getString("url");
-    
-    if (PluginMarker.this.mapCtrl.isDebug) {
-    	Log.d("GoogleMaps", "Setting icon (" + iconUrl + ")");
-    }
-    
     if (iconUrl.indexOf("://") == -1 && 
         iconUrl.startsWith("/") == false && 
         iconUrl.startsWith("www/") == false &&
@@ -702,24 +689,17 @@ public class PluginMarker extends MyPlugin {
     }
     
     if (iconUrl == null) {
-    	Log.d("GoogleMaps", "icon is null (" + iconUrl + ")");
-      	callback.onPostExecute(marker);
-      	return;
+      callback.onPostExecute(marker);
+      return;
     }
     
+    
     if (iconUrl.indexOf("http") != 0) {
-      
-      if (PluginMarker.this.mapCtrl.isDebug) {
-      	Log.d("GoogleMaps", "icon is not http (" + iconUrl + ")");
-      }
       
       AsyncTask<Void, Void, Bitmap> task = new AsyncTask<Void, Void, Bitmap>() {
 
         @Override
         protected Bitmap doInBackground(Void... params) {
-          
-          try {
-          
           String iconUrl = iconProperty.getString("url");
           
           Bitmap image = null;
@@ -787,12 +767,6 @@ public class PluginMarker extends MyPlugin {
             image = PluginUtil.scaleBitmapForDevice(image);
           }
           return image;
-        
-          } catch (Exception e) { // FIXME
-              e.printStackTrace();
-              Log.e("GoogleMaps", "Exception loading image (not from http)", e);
-              return null;
-          }
         }
         
         @Override
@@ -847,11 +821,6 @@ public class PluginMarker extends MyPlugin {
     }
     
     if (iconUrl.indexOf("http") == 0) {
-    	
-      if (PluginMarker.this.mapCtrl.isDebug) {
-      	Log.d("GoogleMaps", "icon is http (" + iconUrl + ")");
-      }
-      
       int width = -1;
       int height = -1;
       if (iconProperty.containsKey("size") == true) {
@@ -917,3 +886,4 @@ public class PluginMarker extends MyPlugin {
     marker.setInfoWindowAnchor((float)(anchorX / imageWidth), (float)(anchorY / imageHeight));
   }
 }
+

--- a/src/android/plugin/google/maps/PluginMarker.java
+++ b/src/android/plugin/google/maps/PluginMarker.java
@@ -52,7 +52,9 @@ public class PluginMarker extends MyPlugin {
     final MarkerOptions markerOptions = new MarkerOptions();
     final JSONObject opts = args.getJSONObject(1);
 	
-    Log.i("GoogleMaps", "Creating marker (" + opts.toString() + ")");
+    if (PluginMarker.this.mapCtrl.isDebug) {
+    	Log.d("GoogleMaps", "Creating marker (" + opts.toString() + ")");
+    }
 	
     if (opts.has("position")) {
         JSONObject position = opts.getJSONObject("position");
@@ -683,7 +685,9 @@ public class PluginMarker extends MyPlugin {
     
     String iconUrl = iconProperty.getString("url");
     
-    Log.i("GoogleMaps", "Setting icon (" + iconUrl + ")");
+    if (PluginMarker.this.mapCtrl.isDebug) {
+    	Log.d("GoogleMaps", "Setting icon (" + iconUrl + ")");
+    }
     
     if (iconUrl.indexOf("://") == -1 && 
         iconUrl.startsWith("/") == false && 
@@ -698,14 +702,16 @@ public class PluginMarker extends MyPlugin {
     }
     
     if (iconUrl == null) {
-    	Log.i("GoogleMaps", "icon is null (" + iconUrl + ")");
+    	Log.d("GoogleMaps", "icon is null (" + iconUrl + ")");
       	callback.onPostExecute(marker);
       	return;
     }
     
     if (iconUrl.indexOf("http") != 0) {
       
-      Log.i("GoogleMaps", "icon is not http (" + iconUrl + ")");
+      if (PluginMarker.this.mapCtrl.isDebug) {
+      	Log.d("GoogleMaps", "icon is not http (" + iconUrl + ")");
+      }
       
       AsyncTask<Void, Void, Bitmap> task = new AsyncTask<Void, Void, Bitmap>() {
 
@@ -842,7 +848,9 @@ public class PluginMarker extends MyPlugin {
     
     if (iconUrl.indexOf("http") == 0) {
     	
-      Log.i("GoogleMaps", "icon is http (" + iconUrl + ")");
+      if (PluginMarker.this.mapCtrl.isDebug) {
+      	Log.d("GoogleMaps", "icon is http (" + iconUrl + ")");
+      }
       
       int width = -1;
       int height = -1;

--- a/src/android/plugin/google/maps/PluginMarker.java
+++ b/src/android/plugin/google/maps/PluginMarker.java
@@ -52,7 +52,7 @@ public class PluginMarker extends MyPlugin {
     final MarkerOptions markerOptions = new MarkerOptions();
     final JSONObject opts = args.getJSONObject(1);
 	
-	Log.i("GoogleMaps", "Creating marker (" + opts.toString() + ")", e);
+	Log.i("GoogleMaps", "Creating marker (" + opts.toString() + ")");
 	
     if (opts.has("position")) {
         JSONObject position = opts.getJSONObject("position");

--- a/src/android/plugin/google/maps/PluginMarker.java
+++ b/src/android/plugin/google/maps/PluginMarker.java
@@ -790,6 +790,7 @@ public class PluginMarker extends MyPlugin {
           } catch (Exception e) { // FIXME
               e.printStackTrace();
               Log.e("TAG3", "Exception: ", e);
+              return null;
           }
         }
         

--- a/src/android/plugin/google/maps/PluginMarker.java
+++ b/src/android/plugin/google/maps/PluginMarker.java
@@ -52,7 +52,7 @@ public class PluginMarker extends MyPlugin {
     final MarkerOptions markerOptions = new MarkerOptions();
     final JSONObject opts = args.getJSONObject(1);
 	
-	Log.i("GoogleMaps", "Creating marker (" + opts.toString() + ")");
+    Log.i("GoogleMaps", "Creating marker (" + opts.toString() + ")");
 	
     if (opts.has("position")) {
         JSONObject position = opts.getJSONObject("position");
@@ -682,6 +682,9 @@ public class PluginMarker extends MyPlugin {
     }
     
     String iconUrl = iconProperty.getString("url");
+    
+    Log.i("GoogleMaps", "Setting icon (" + iconUrl + ")");
+    
     if (iconUrl.indexOf("://") == -1 && 
         iconUrl.startsWith("/") == false && 
         iconUrl.startsWith("www/") == false) {

--- a/src/android/plugin/google/maps/PluginMarker.java
+++ b/src/android/plugin/google/maps/PluginMarker.java
@@ -155,8 +155,6 @@ public class PluginMarker extends MyPlugin {
         bundle.putString("animation", opts.getString("animation"));
       }
       
-      try {
-      
       this.setIcon_(marker, bundle, new PluginAsyncInterface() {
 
         @Override
@@ -165,7 +163,10 @@ public class PluginMarker extends MyPlugin {
           if (opts.has("visible")) {
             try {
               marker.setVisible(opts.getBoolean("visible"));
-            } catch (JSONException e) {}
+            } catch (Exception e) {
+              e.printStackTrace();
+              Log.e("XXX", "Exception: ", e);
+            }
           } else {
             marker.setVisible(true);
           }
@@ -206,11 +207,6 @@ public class PluginMarker extends MyPlugin {
         }
         
       });
-    
-      } catch (Exception e) {
-        e.printStackTrace();
-        Log.e("TAG1", "Exception: ", e);
-      }
     } else {
       String markerAnimation = null;
       if (opts.has("animation")) {
@@ -659,8 +655,6 @@ public class PluginMarker extends MyPlugin {
     }
     if (bundle != null) {
       
-      try{
-      
       this.setIcon_(marker, bundle, new PluginAsyncInterface() {
 
         @Override
@@ -673,12 +667,6 @@ public class PluginMarker extends MyPlugin {
           callbackContext.error(errorMsg);
         }
       });
-      
-      } catch (Exception e) {
-        e.printStackTrace();
-        Log.e("TAG2", "Exception: ", e);
-      }
-      
     } else {
       this.sendNoResult(callbackContext);
     }

--- a/src/android/plugin/google/maps/PluginMarker.java
+++ b/src/android/plugin/google/maps/PluginMarker.java
@@ -52,7 +52,7 @@ public class PluginMarker extends MyPlugin {
     final MarkerOptions markerOptions = new MarkerOptions();
     final JSONObject opts = args.getJSONObject(1);
 	
-	Log.i("GoogleMaps", "Creating marker (" + opts.toString() + "), e);
+	Log.i("GoogleMaps", "Creating marker (" + opts.toString() + ")", e);
 	
     if (opts.has("position")) {
         JSONObject position = opts.getJSONObject("position");

--- a/src/android/plugin/google/maps/PluginMarker.java
+++ b/src/android/plugin/google/maps/PluginMarker.java
@@ -209,6 +209,7 @@ public class PluginMarker extends MyPlugin {
     
       } catch (Exception e) {
         e.printStackTrace();
+        Log.e("TAG1", "Exception: ", e);
       }
     } else {
       String markerAnimation = null;
@@ -670,6 +671,7 @@ public class PluginMarker extends MyPlugin {
         @Override
         public void onError(String errorMsg) {
           callbackContext.error(errorMsg);
+          Log.e("TAG2", "Exception: ", e);
         }
       });
       

--- a/src/android/plugin/google/maps/PluginMarker.java
+++ b/src/android/plugin/google/maps/PluginMarker.java
@@ -715,8 +715,9 @@ public class PluginMarker extends MyPlugin {
           
           if (iconUrl.indexOf("data:image/") == 0 && iconUrl.indexOf(";base64,") > -1) {
             String[] tmp = iconUrl.split(",");
+            Log.e("GoogleMaps", "making bitmap from base64");
             image = PluginUtil.getBitmapFromBase64encodedImage(tmp[1]);
-            Log.w("GoogleMaps", "bitmap from base64 (" + (image != null ? "sucess" : "fail"));
+            Log.e("GoogleMaps", "maked bitmap from base64 (" + (image != null ? "sucess" : "fail"));
           } else if (iconUrl.indexOf("file://") == 0 &&
               iconUrl.indexOf("file:///android_asset/") == -1) {
             iconUrl = iconUrl.replace("file://", "");

--- a/src/android/plugin/google/maps/PluginMarker.java
+++ b/src/android/plugin/google/maps/PluginMarker.java
@@ -51,6 +51,9 @@ public class PluginMarker extends MyPlugin {
     // Create an instance of Marker class
     final MarkerOptions markerOptions = new MarkerOptions();
     final JSONObject opts = args.getJSONObject(1);
+	
+	Log.i("GoogleMaps", "Creating marker (" + opts.toString() + "), e);
+	
     if (opts.has("position")) {
         JSONObject position = opts.getJSONObject("position");
         markerOptions.position(new LatLng(position.getDouble("lat"), position.getDouble("lng")));
@@ -168,7 +171,7 @@ public class PluginMarker extends MyPlugin {
             }
           } catch (Exception e) {
             e.printStackTrace();
-            Log.e("XXX", "Exception: ", e);
+            Log.e("GoogleMaps", "Exception setting visible", e);
           }
           // Animation
           String markerAnimation = null;
@@ -695,9 +698,6 @@ public class PluginMarker extends MyPlugin {
       return;
     }
     
-    Log.e("XXXX", "XXX bitmap base64 " + iconUrl);
-    Log.w("XXXX", "XXX bitmap base64 " + iconUrl);
-    
     if (iconUrl.indexOf("http") != 0) {
       
       AsyncTask<Void, Void, Bitmap> task = new AsyncTask<Void, Void, Bitmap>() {
@@ -717,9 +717,7 @@ public class PluginMarker extends MyPlugin {
           
           if (iconUrl.indexOf("data:image/") == 0 && iconUrl.indexOf(";base64,") > -1) {
             String[] tmp = iconUrl.split(",");
-            Log.e("GoogleMaps", "making bitmap from base64");
             image = PluginUtil.getBitmapFromBase64encodedImage(tmp[1]);
-            Log.e("GoogleMaps", "maked bitmap from base64 (" + (image != null ? "sucess" : "fail"));
           } else if (iconUrl.indexOf("file://") == 0 &&
               iconUrl.indexOf("file:///android_asset/") == -1) {
             iconUrl = iconUrl.replace("file://", "");
@@ -779,7 +777,7 @@ public class PluginMarker extends MyPlugin {
         
           } catch (Exception e) { // FIXME
               e.printStackTrace();
-              Log.e("XXX3", "Exception: ", e);
+              Log.e("GoogleMaps", "Exception loading image (not from http)", e);
               return null;
           }
         }

--- a/src/android/plugin/google/maps/PluginMarker.java
+++ b/src/android/plugin/google/maps/PluginMarker.java
@@ -154,6 +154,9 @@ public class PluginMarker extends MyPlugin {
       if (opts.has("animation")) {
         bundle.putString("animation", opts.getString("animation"));
       }
+      
+      try {
+      
       this.setIcon_(marker, bundle, new PluginAsyncInterface() {
 
         @Override
@@ -203,6 +206,10 @@ public class PluginMarker extends MyPlugin {
         }
         
       });
+    
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
     } else {
       String markerAnimation = null;
       if (opts.has("animation")) {
@@ -650,6 +657,9 @@ public class PluginMarker extends MyPlugin {
       bundle.putString("url", (String)value);
     }
     if (bundle != null) {
+      
+      try{
+      
       this.setIcon_(marker, bundle, new PluginAsyncInterface() {
 
         @Override
@@ -662,6 +672,11 @@ public class PluginMarker extends MyPlugin {
           callbackContext.error(errorMsg);
         }
       });
+      
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+      
     } else {
       this.sendNoResult(callbackContext);
     }


### PR DESCRIPTION
I added also some debug information under (isDebug variable).

The key is mainly add (iconUrl.startsWith("data:image") == false) to line 695. If you don't put this, a icon value with "data/image ..." is modified by the adding of "./".

I don't know why I am the only one with this problem.