### PR TITLE
Fixing bug that add ./ and then the url to the icon value when is passed a base64 image

### DIFF
--- a/src/android/plugin/google/maps/PluginMarker.java
+++ b/src/android/plugin/google/maps/PluginMarker.java
@@ -678,7 +678,8 @@ public class PluginMarker extends MyPlugin {
     String iconUrl = iconProperty.getString("url");
     if (iconUrl.indexOf("://") == -1 && 
         iconUrl.startsWith("/") == false && 
-        iconUrl.startsWith("www/") == false) {
+        iconUrl.startsWith("www/") == false &&
+        iconUrl.startsWith("data:image") == false) {
       iconUrl = "./" + iconUrl;
     }
     if (iconUrl.indexOf("./") == 0) {


### PR DESCRIPTION
Adding `iconUrl.startsWith("data:image") == false` to line 682 you avoid that the string "./" was added to the icon content when this is a base64 image.

I don't know why I am the only one with this problem.

(Note: I deleted and created again the repository (muerto el perro se acabo la rabia)).