### PR TITLE
Update plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -122,7 +122,7 @@
                 <param name="ios-package" value="Geocoder" />
             </feature>
             <feature name="GroundOverlay">
-                <param name="ios-package" value="GroundOvderlay" />
+                <param name="ios-package" value="GroundOverlay" />
             </feature>
             <feature name="KmlOverlay">
                 <param name="ios-package" value="KmlOverlay" />


### PR DESCRIPTION
Fix typo, which prevents GroundOverlay from working in latest build on iOS.

Without this change you get:

`Class not found: GroundOverlay`

When trying to add a ground overlay (for obvious reasons).