### PR TITLE
New getAllChildren implementation

### DIFF
--- a/www/googlemaps-cdv-plugin.js
+++ b/www/googlemaps-cdv-plugin.js
@@ -2675,31 +2675,27 @@ window.addEventListener("orientationchange", function() {
 function getAllChildren(root) {
     var list = [];
     var clickable;
-    var style, displayCSS, opacityCSS, visibilityCSS;
-    var search = function(node) {
-        while (node != null) {
-            if (node.nodeType == 1) {
-                style = window.getComputedStyle(node);
-                visibilityCSS = style.getPropertyValue('visibility');
-                displayCSS = style.getPropertyValue('display');
-                opacityCSS = style.getPropertyValue('opacity');
-                if (displayCSS !== "none" && opacityCSS > 0 && visibilityCSS != "hidden") {
-                    clickable = node.getAttribute("data-clickable");
-                    if (clickable &&
-                        clickable.toLowerCase() === "false" &&
-                        node.hasChildNodes()) {
-                        Array.prototype.push.apply(list, getAllChildren(node));
-                    } else {
-                        list.push(node);
-                    }
-                }
-            }
-            node = node.nextSibling;
+    var style, displayCSS, opacityCSS, visibilityCSS, node, clickableSize;
+
+    var allClickableElements = Array.prototype.slice.call(root.querySelectorAll(':not([data-clickable="false"])'));
+    var clickableElements =  allClickableElements.filter(function(i) {return i != root;});
+
+    for (var i = 0; i < clickableElements.length; i++) {
+        node = clickableElements[i];
+        if (node.nodeType == 1){
+          style = window.getComputedStyle(node);
+          visibilityCSS = style.getPropertyValue('visibility');
+          displayCSS = style.getPropertyValue('display');
+          opacityCSS = style.getPropertyValue('opacity');
+          heightCSS = style.getPropertyValue('height')
+          widthCSS = style.getPropertyValue('width')
+          clickableSize = (heightCSS != "0px" && widthCSS != "0px" && node.clientHeight > 0 && node.clientWidth > 0);
+          if (displayCSS !== "none" && opacityCSS > 0 && visibilityCSS != "hidden" && clickableSize) {
+            list.push(node);
+          }
         }
-    };
-    for (var i = 0; i < root.childNodes.length; i++) {
-        search(root.childNodes[i]);
     }
+
     return list;
 }
 


### PR DESCRIPTION
Greatly increase the performance when looking for children elements of the div containing the map by using querySelectorAll instead of recursive search:

Time to getAllChildren before the new implementation:
![captura de pantalla 2016-03-29 a las 18 37 18](https://cloud.githubusercontent.com/assets/818328/14404932/f7969e9c-fe82-11e5-87b4-0c7364ef7664.png)


Time to getAllChildren with the new implementation:
![captura de pantalla 2016-03-29 a las 19 29 34](https://cloud.githubusercontent.com/assets/818328/14404935/05b8790a-fe83-11e5-8097-472ba141b517.png)


