### PR TITLE
fix a bug who send wrong list of DOM map children

### DIFF
--- a/www/googlemaps-cdv-plugin.js
+++ b/www/googlemaps-cdv-plugin.js
@@ -2697,9 +2697,7 @@ function getAllChildren(root) {
             node = node.nextSibling;
         }
     };
-    for (var i = 0; i < root.childNodes.length; i++) {
-        search(root.childNodes[i]);
-    }
+    search(root.firstChild);
     return list;
 }
 


### PR DESCRIPTION
I am using some functions in a Mapbox port and I found a bug when treating the children element of a map in `getAllChildren()`

For exemple:
```
<div id="map_canvas">
 <button>
 <button>
 <button>
 <button>
 <button>
 <button>
 <button>
 <button>
 <button>
 <button>
 <button>
 <button>
 <button>
 <button>
<div>
```
will send near 100 children instead of 14. It is because the search function is launched for each root children instead of the first one. So that duplicate the list.