### PR TITLE
Add setMapToolbarEnabled function for Android

### DIFF
--- a/src/android/plugin/google/maps/PluginMap.java
+++ b/src/android/plugin/google/maps/PluginMap.java
@@ -38,12 +38,12 @@ public class PluginMap extends MyPlugin {
   /**
    * @param args
    * @param callbackContext
-   * @throws JSONException 
+   * @throws JSONException
    */
   @SuppressWarnings("unused")
   private void setOptions(JSONArray args, CallbackContext callbackContext) throws JSONException {
 
-    
+
     UiSettings settings = this.map.getUiSettings();
     JSONObject params = args.getJSONObject(1);
     //controls
@@ -59,11 +59,14 @@ public class PluginMap extends MyPlugin {
       if (controls.has("indoorPicker")) {
         settings.setIndoorLevelPickerEnabled(controls.getBoolean("indoorPicker"));
       }
+      if (controls.has("mapToolbar")) {
+        settings.setMapToolbarEnabled(controls.getBoolean("mapToolbar"));
+      }
       if (controls.has("myLocationButton")) {
         settings.setMyLocationButtonEnabled(controls.getBoolean("myLocationButton"));
       }
     }
-    
+
     //gestures
     if (params.has("gestures")) {
       JSONObject gestures = params.getJSONObject("gestures");
@@ -82,7 +85,7 @@ public class PluginMap extends MyPlugin {
         settings.setZoomGesturesEnabled(gestures.getBoolean("zoom"));
       }
     }
-    
+
     // map type
     if (params.has("mapType")) {
       String typeStr = params.getString("mapType");
@@ -101,7 +104,7 @@ public class PluginMap extends MyPlugin {
         this.map.setMapType(mapTypeId);
       }
     }
-    
+
     //controls
     Boolean isEnabled = true;
 
@@ -162,12 +165,12 @@ public class PluginMap extends MyPlugin {
       this.sendNoResult(callbackContext);
     }
   }
-  
+
   /**
    * Set center location of the marker
    * @param args
    * @param callbackContext
-   * @throws JSONException 
+   * @throws JSONException
    */
   @SuppressWarnings("unused")
   private void setCenter(JSONArray args, CallbackContext callbackContext) throws JSONException {
@@ -185,7 +188,7 @@ public class PluginMap extends MyPlugin {
    * Set angle of the map view
    * @param args
    * @param callbackContext
-   * @throws JSONException 
+   * @throws JSONException
    */
   @SuppressWarnings("unused")
   private void setTilt(final JSONArray args, final CallbackContext callbackContext) throws JSONException {
@@ -207,33 +210,33 @@ public class PluginMap extends MyPlugin {
    * Move the camera with animation
    * @param args
    * @param callbackContext
-   * @throws JSONException 
+   * @throws JSONException
    */
   @SuppressWarnings("unused")
   private void animateCamera(JSONArray args, CallbackContext callbackContext) throws JSONException {
     this.updateCameraPosition("animateCamera", args, callbackContext);
   }
-  
+
   /**
    * Move the camera without animation
    * @param args
    * @param callbackContext
-   * @throws JSONException 
+   * @throws JSONException
    */
   @SuppressWarnings("unused")
   private void moveCamera(JSONArray args, CallbackContext callbackContext) throws JSONException {
     this.updateCameraPosition("moveCamera", args, callbackContext);
   }
-  
+
   /**
    * move the camera
    * @param action
    * @param args
    * @param callbackContext
-   * @throws JSONException 
+   * @throws JSONException
    */
   private void updateCameraPosition(final String action, final JSONArray args, final CallbackContext callbackContext) throws JSONException {
-    
+
     int durationMS = 4000;
     CameraPosition.Builder builder = CameraPosition.builder();
     final JSONObject cameraPos = args.getJSONObject(1);
@@ -314,7 +317,7 @@ public class PluginMap extends MyPlugin {
    * Set zoom of the map
    * @param args
    * @param callbackContext
-   * @throws JSONException 
+   * @throws JSONException
    */
   @SuppressWarnings("unused")
   private void setZoom(JSONArray args, CallbackContext callbackContext) throws JSONException {
@@ -328,7 +331,7 @@ public class PluginMap extends MyPlugin {
    * Pan by the specified pixel
    * @param args
    * @param callbackContext
-   * @throws JSONException 
+   * @throws JSONException
    */
   @SuppressWarnings("unused")
   private void panBy(JSONArray args, CallbackContext callbackContext) throws JSONException {
@@ -336,11 +339,11 @@ public class PluginMap extends MyPlugin {
     int y = args.getInt(2);
     float xPixel = -x * this.density;
     float yPixel = -y * this.density;
-    
+
     CameraUpdate cameraUpdate = CameraUpdateFactory.scrollBy(xPixel, yPixel);
     map.animateCamera(cameraUpdate);
   }
-  
+
   /**
    * Move the camera of the map
    * @param cameraPosition
@@ -365,7 +368,7 @@ public class PluginMap extends MyPlugin {
    * Enable MyLocation feature if set true
    * @param args
    * @param callbackContext
-   * @throws JSONException 
+   * @throws JSONException
    */
   @SuppressWarnings("unused")
   private void setMyLocationEnabled(final JSONArray args, final CallbackContext callbackContext) throws JSONException {
@@ -420,7 +423,7 @@ public class PluginMap extends MyPlugin {
    * Enable Indoor map feature if set true
    * @param args
    * @param callbackContext
-   * @throws JSONException 
+   * @throws JSONException
    */
   @SuppressWarnings("unused")
   private void setIndoorEnabled(final JSONArray args, final CallbackContext callbackContext) throws JSONException {
@@ -430,10 +433,24 @@ public class PluginMap extends MyPlugin {
   }
 
   /**
+   * Enable the map toolbar if set true
+   * @param args
+   * @param callbackContext
+   * @throws JSONException
+   */
+  @SuppressWarnings("unused")
+  private void setMapToolbarEnabled(final JSONArray args, final CallbackContext callbackContext) throws JSONException {
+    Boolean isEnabled = args.getBoolean(1);
+    UiSettings uiSettings = map.getUiSettings();
+    uiSettings.setsetMapToolbarEnabled(isEnabled);
+    this.sendNoResult(callbackContext);
+  }
+
+  /**
    * Enable the traffic layer if set true
    * @param args
    * @param callbackContext
-   * @throws JSONException 
+   * @throws JSONException
    */
   @SuppressWarnings("unused")
   private void setTrafficEnabled(final JSONArray args, final CallbackContext callbackContext) throws JSONException {
@@ -446,7 +463,7 @@ public class PluginMap extends MyPlugin {
    * Enable the compass if set true
    * @param args
    * @param callbackContext
-   * @throws JSONException 
+   * @throws JSONException
    */
   @SuppressWarnings("unused")
   private void setCompassEnabled(final JSONArray args, final CallbackContext callbackContext) throws JSONException {
@@ -460,7 +477,7 @@ public class PluginMap extends MyPlugin {
    * Change the map type id of the map
    * @param args
    * @param callbackContext
-   * @throws JSONException 
+   * @throws JSONException
    */
   @SuppressWarnings("unused")
   private void setMapTypeId(JSONArray args, final CallbackContext callbackContext) throws JSONException {
@@ -481,7 +498,7 @@ public class PluginMap extends MyPlugin {
       callbackContext.error("Unknown MapTypeID is specified:" + typeStr);
       return;
     }
-    
+
     final int myMapTypeId = mapTypeId;
     map.setMapType(myMapTypeId);
     this.sendNoResult(callbackContext);
@@ -513,13 +530,13 @@ public class PluginMap extends MyPlugin {
       map.animateCamera(cameraUpdate, callback);
     }
   }
-  
+
 
   /**
    * Return the current position of the camera
    * @param args
    * @param callbackContext
-   * @throws JSONException 
+   * @throws JSONException
    */
   @SuppressWarnings("unused")
   private void getCameraPosition(final JSONArray args, final CallbackContext callbackContext) throws JSONException {
@@ -533,15 +550,15 @@ public class PluginMap extends MyPlugin {
     json.put("tilt", camera.tilt);
     json.put("bearing", camera.bearing);
     json.put("hashCode", camera.hashCode());
-    
+
     callbackContext.success(json);
   }
-  
+
   /**
    * Return the image data encoded with base64
    * @param args
    * @param callbackContext
-   * @throws JSONException 
+   * @throws JSONException
    */
   @SuppressWarnings("unused")
   private void toDataURL(final JSONArray args, final CallbackContext callbackContext) throws JSONException {
@@ -555,7 +572,7 @@ public class PluginMap extends MyPlugin {
 
 
     this.map.snapshot(new GoogleMap.SnapshotReadyCallback() {
-      
+
       @Override
       public void onSnapshotReady(Bitmap image) {
         if (!finalUncompress) {
@@ -564,16 +581,16 @@ public class PluginMap extends MyPlugin {
               (int) (image.getWidth() / density),
               (int) (image.getHeight() / density));
         }
-        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();  
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         image.compress(Bitmap.CompressFormat.PNG, 100, outputStream);
         byte[] byteArray = outputStream.toByteArray();
-        String imageEncoded = "data:image/png;base64," + 
+        String imageEncoded = "data:image/png;base64," +
                 Base64.encodeToString(byteArray, Base64.NO_WRAP);
-        
+
         callbackContext.success(imageEncoded);
       }
     });
-    
+
   }
   @SuppressWarnings({ "unused" })
   private void fromLatLngToPoint(final JSONArray args, final CallbackContext callbackContext) throws JSONException {
@@ -587,7 +604,7 @@ public class PluginMap extends MyPlugin {
     pointJSON.put(point.y / this.density);
     callbackContext.success(pointJSON);
   }
-  
+
   @SuppressWarnings("unused")
   private void fromPointToLatLng(final JSONArray args, final CallbackContext callbackContext) throws JSONException {
     int pointX, pointY;
@@ -602,7 +619,7 @@ public class PluginMap extends MyPlugin {
     pointJSON.put(latlng.longitude);
     callbackContext.success(pointJSON);
   }
-  
+
   /**
    * Return the visible region of the map
    * Thanks @fschmidt
@@ -620,21 +637,21 @@ public class PluginMap extends MyPlugin {
     southwest.put("lng", latLngBounds.southwest.longitude);
     result.put("northeast", northeast);
     result.put("southwest", southwest);
-    
+
     JSONArray latLngArray = new JSONArray();
     latLngArray.put(northeast);
     latLngArray.put(southwest);
     result.put("latLngArray", latLngArray);
-    
+
     callbackContext.success(result);
   }
-  
+
 
   /**
    * Sets the preference for whether all gestures should be enabled or disabled.
    * @param args
    * @param callbackContext
-   * @throws JSONException 
+   * @throws JSONException
    */
   @SuppressWarnings("unused")
   private void setAllGesturesEnabled(final JSONArray args, final CallbackContext callbackContext) throws JSONException {
@@ -648,7 +665,7 @@ public class PluginMap extends MyPlugin {
    * Sets padding of the map
    * @param args
    * @param callbackContext
-   * @throws JSONException 
+   * @throws JSONException
    */
   @SuppressWarnings("unused")
   private void setPadding(final JSONArray args, final CallbackContext callbackContext) throws JSONException {

--- a/src/ios/GoogleMaps/Map.m
+++ b/src/ios/GoogleMaps/Map.m
@@ -20,12 +20,12 @@
  * Move the center of the map
  */
 - (void)setCenter:(CDVInvokedUrlCommand *)command {
-  
+
   float latitude = [[command.arguments objectAtIndex:1] floatValue];
   float longitude = [[command.arguments objectAtIndex:2] floatValue];
-  
+
   [self.mapCtrl.map animateToLocation:CLLocationCoordinate2DMake(latitude, longitude)];
-  
+
   CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
@@ -34,7 +34,7 @@
   Boolean isEnabled = [[command.arguments objectAtIndex:1] boolValue];
   self.mapCtrl.map.settings.myLocationButton = isEnabled;
   self.mapCtrl.map.myLocationEnabled = isEnabled;
-  
+
   CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
@@ -43,7 +43,13 @@
   Boolean isEnabled = [[command.arguments objectAtIndex:1] boolValue];
   self.mapCtrl.map.settings.indoorPicker = isEnabled;
   self.mapCtrl.map.indoorEnabled = isEnabled;
-  
+
+  CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+  [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
+- (void)setMapToolbarEnabled:(CDVInvokedUrlCommand *)command {
+  // Stub - this feature is not available on iOS. Prevent crashes by returning OK status.
   CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
@@ -51,7 +57,7 @@
 - (void)setTrafficEnabled:(CDVInvokedUrlCommand *)command {
   Boolean isEnabled = [[command.arguments objectAtIndex:1] boolValue];
   self.mapCtrl.map.trafficEnabled = isEnabled;
-  
+
   CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
@@ -59,14 +65,14 @@
 - (void)setCompassEnabled:(CDVInvokedUrlCommand *)command {
   Boolean isEnabled = [[command.arguments objectAtIndex:1] boolValue];
   self.mapCtrl.map.settings.compassButton = isEnabled;
-  
+
   CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
 - (void)setTilt:(CDVInvokedUrlCommand *)command {
-  
-  
+
+
   CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
@@ -74,7 +80,7 @@
 - (void)setAllGesturesEnabled:(CDVInvokedUrlCommand *)command {
   Boolean isEnabled = [[command.arguments objectAtIndex:1] boolValue];
   [self.mapCtrl.map.settings setAllGesturesEnabled:isEnabled];
-  
+
   CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
@@ -86,9 +92,9 @@
 - (void)setZoom:(CDVInvokedUrlCommand *)command {
   float zoom = [[command.arguments objectAtIndex:1] floatValue];
   CLLocationCoordinate2D center = [self.mapCtrl.map.projection coordinateForPoint:self.mapCtrl.map.center];
-  
+
   [self.mapCtrl.map setCamera:[GMSCameraPosition cameraWithTarget:center zoom:zoom]];
-  
+
   CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
@@ -99,9 +105,9 @@
 - (void)panBy:(CDVInvokedUrlCommand *)command {
   int x = [[command.arguments objectAtIndex:1] intValue];
   int y = [[command.arguments objectAtIndex:2] intValue];
-  
+
   [self.mapCtrl.map animateWithCameraUpdate:[GMSCameraUpdate scrollByX:x * -1 Y:y * -1]];
-  
+
   CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
@@ -111,7 +117,7 @@
  */
 - (void)setMapTypeId:(CDVInvokedUrlCommand *)command {
   CDVPluginResult* pluginResult = nil;
-  
+
   NSString *typeStr = [command.arguments objectAtIndex:1];
   NSDictionary *mapTypes = [NSDictionary dictionaryWithObjectsAndKeys:
                             ^() {return kGMSTypeHybrid; }, @"MAP_TYPE_HYBRID",
@@ -120,7 +126,7 @@
                             ^() {return kGMSTypeNormal; }, @"MAP_TYPE_NORMAL",
                             ^() {return kGMSTypeNone; }, @"MAP_TYPE_NONE",
                             nil];
-  
+
   typedef GMSMapViewType (^CaseBlock)();
   GMSMapViewType mapType;
   CaseBlock caseBlock = mapTypes[typeStr];
@@ -157,11 +163,11 @@
 -(void)getCameraPosition:(CDVInvokedUrlCommand *)command
 {
   GMSCameraPosition *camera = self.mapCtrl.map.camera;
-  
+
   NSMutableDictionary *latLng = [NSMutableDictionary dictionary];
   [latLng setObject:[NSNumber numberWithFloat:camera.target.latitude] forKey:@"lat"];
   [latLng setObject:[NSNumber numberWithFloat:camera.target.longitude] forKey:@"lng"];
-  
+
   NSMutableDictionary *json = [NSMutableDictionary dictionary];
   [json setObject:[NSNumber numberWithFloat:camera.zoom] forKey:@"zoom"];
   [json setObject:[NSNumber numberWithDouble:camera.viewingAngle] forKey:@"tilt"];
@@ -175,19 +181,19 @@
 
 -(void)updateCameraPosition: (NSString*)action command:(CDVInvokedUrlCommand *)command {
   NSDictionary *json = [command.arguments objectAtIndex:1];
-  
+
   int bearing = (int)[[json valueForKey:@"bearing"] integerValue];
   double angle = [[json valueForKey:@"tilt"] doubleValue];
   double zoom = [[json valueForKey:@"zoom"] doubleValue];
-  
-  
+
+
   NSDictionary *latLng = nil;
   float latitude;
   float longitude;
   GMSCameraPosition *cameraPosition;
   GMSCoordinateBounds *cameraBounds = nil;
-  
-  
+
+
   if ([json objectForKey:@"target"]) {
     NSString *targetClsName = [[json objectForKey:@"target"] className];
     if ([targetClsName isEqualToString:@"__NSCFArray"] || [targetClsName isEqualToString:@"__NSArrayM"] ) {
@@ -205,17 +211,17 @@
         scale = [[UIScreen mainScreen] scale];
       }
       [[UIScreen mainScreen] scale];
-      
+
       cameraBounds = [[GMSCoordinateBounds alloc] initWithPath:path];
       //CLLocationCoordinate2D center = cameraBounds.center;
-      
+
       cameraPosition = [self.mapCtrl.map cameraForBounds:cameraBounds insets:UIEdgeInsetsMake(10 * scale, 10* scale, 10* scale, 10* scale)];
-    
+
     } else {
       latLng = [json objectForKey:@"target"];
       latitude = [[latLng valueForKey:@"lat"] floatValue];
       longitude = [[latLng valueForKey:@"lng"] floatValue];
-      
+
       cameraPosition = [GMSCameraPosition cameraWithLatitude:latitude
                                           longitude:longitude
                                           zoom:zoom
@@ -229,57 +235,57 @@
                                         bearing:bearing
                                         viewingAngle:angle];
   }
-  
+
   float duration = 5.0f;
   if ([json objectForKey:@"duration"]) {
     duration = [[json objectForKey:@"duration"] floatValue] / 1000;
   }
-  
+
   CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
-  
+
   if ([action  isEqual: @"animateCamera"]) {
     [CATransaction begin]; {
       [CATransaction setAnimationDuration: duration];
-      
+
       //[CATransaction setAnimationTimingFunction:[CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseIn]];
       [CATransaction setAnimationTimingFunction:[CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseInEaseOut]];
-      
+
       [CATransaction setCompletionBlock:^{
         if (cameraBounds != nil){
-        
+
           GMSCameraPosition *cameraPosition2 = [GMSCameraPosition cameraWithLatitude:cameraBounds.center.latitude
                                               longitude:cameraBounds.center.longitude
                                               zoom:self.mapCtrl.map.camera.zoom
                                               bearing:[[json objectForKey:@"bearing"] doubleValue]
                                               viewingAngle:[[json objectForKey:@"tilt"] doubleValue]];
-        
+
           [self.mapCtrl.map setCamera:cameraPosition2];
         }
         [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
       }];
-      
+
       [self.mapCtrl.map animateToCameraPosition: cameraPosition];
     }[CATransaction commit];
   }
-  
+
   if ([action  isEqual: @"moveCamera"]) {
     [self.mapCtrl.map setCamera:cameraPosition];
 
     if (cameraBounds != nil){
-    
+
       GMSCameraPosition *cameraPosition2 = [GMSCameraPosition cameraWithLatitude:cameraBounds.center.latitude
                                           longitude:cameraBounds.center.longitude
                                           zoom:self.mapCtrl.map.camera.zoom
                                           bearing:[[json objectForKey:@"bearing"] doubleValue]
                                           viewingAngle:[[json objectForKey:@"tilt"] doubleValue]];
-    
+
       [self.mapCtrl.map setCamera:cameraPosition2];
     }
 
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
   }
 
-  
+
 }
 
 
@@ -290,7 +296,7 @@
   if ([opts objectForKey:@"uncompress"]) {
       uncompress = [[opts objectForKey:@"uncompress"] boolValue];
   }
-  
+
   if (uncompress) {
     UIGraphicsBeginImageContextWithOptions(self.mapCtrl.view.frame.size, NO, 0.0f);
   } else {
@@ -303,7 +309,7 @@
   NSData *imageData = UIImagePNGRepresentation(image);
   NSString *base64Encoded = nil;
   base64Encoded = [NSString stringWithFormat:@"data:image/png;base64,%@", [imageData base64EncodedStringWithSeparateLines:NO]];
-  
+
   CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:base64Encoded];
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
@@ -312,17 +318,17 @@
  * Maps an Earth coordinate to a point coordinate in the map's view.
  */
 - (void)fromLatLngToPoint:(CDVInvokedUrlCommand*)command {
-  
+
   float latitude = [[command.arguments objectAtIndex:1] floatValue];
   float longitude = [[command.arguments objectAtIndex:2] floatValue];
-  
+
   CGPoint point = [self.mapCtrl.map.projection
                       pointForCoordinate:CLLocationCoordinate2DMake(latitude, longitude)];
-  
+
   NSMutableArray *pointJSON = [[NSMutableArray alloc] init];
   [pointJSON addObject:[NSNumber numberWithDouble:point.x]];
   [pointJSON addObject:[NSNumber numberWithDouble:point.y]];
-  
+
   CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArray:pointJSON];
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
@@ -331,17 +337,17 @@
  * Maps a point coordinate in the map's view to an Earth coordinate.
  */
 - (void)fromPointToLatLng:(CDVInvokedUrlCommand*)command {
-  
+
   float pointX = [[command.arguments objectAtIndex:1] floatValue];
   float pointY = [[command.arguments objectAtIndex:2] floatValue];
-  
+
   CLLocationCoordinate2D latLng = [self.mapCtrl.map.projection
                       coordinateForPoint:CGPointMake(pointX, pointY)];
-  
+
   NSMutableArray *latLngJSON = [[NSMutableArray alloc] init];
   [latLngJSON addObject:[NSNumber numberWithDouble:latLng.latitude]];
   [latLngJSON addObject:[NSNumber numberWithDouble:latLng.longitude]];
-  
+
   CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArray:latLngJSON];
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
@@ -363,7 +369,7 @@
   [southwest setObject:[NSNumber numberWithFloat:bounds.southWest.latitude] forKey:@"lat"];
   [southwest setObject:[NSNumber numberWithFloat:bounds.southWest.longitude] forKey:@"lng"];
   [json setObject:southwest forKey:@"southwest"];
-  
+
   NSMutableArray *latLngArray = [NSMutableArray array];
   [latLngArray addObject:northeast];
   [latLngArray addObject:southwest];
@@ -382,7 +388,7 @@
     NSMutableDictionary *latLng = [NSMutableDictionary dictionary];
     [latLng setObject:[NSNumber numberWithFloat:0.0f] forKey:@"lat"];
     [latLng setObject:[NSNumber numberWithFloat:0.0f] forKey:@"lng"];
-    
+
     if (cameraOpts) {
       NSDictionary *latLngJSON = [cameraOpts objectForKey:@"latLng"];
       [latLng setObject:[NSNumber numberWithFloat:[[latLngJSON valueForKey:@"lat"] floatValue]] forKey:@"lat"];
@@ -394,7 +400,7 @@
                                   zoom: [[cameraOpts valueForKey:@"zoom"] floatValue]
                                   bearing:[[cameraOpts objectForKey:@"bearing"] doubleValue]
                                   viewingAngle:[[cameraOpts objectForKey:@"tilt"] doubleValue]];
-    
+
     self.mapCtrl.map.camera = camera;
   }
 */
@@ -426,22 +432,22 @@
           scale = [[UIScreen mainScreen] scale];
         }
         [[UIScreen mainScreen] scale];
-        
+
         cameraBounds = [[GMSCoordinateBounds alloc] initWithPath:path];
-        
+
         CLLocationCoordinate2D center = cameraBounds.center;
-        
+
         camera = [GMSCameraPosition cameraWithLatitude:center.latitude
                                             longitude:center.longitude
                                             zoom:self.mapCtrl.map.camera.zoom
                                             bearing:[[cameraOpts objectForKey:@"bearing"] doubleValue]
                                             viewingAngle:[[cameraOpts objectForKey:@"tilt"] doubleValue]];
-        
+
       } else {
         latLng = [cameraOpts objectForKey:@"target"];
         latitude = [[latLng valueForKey:@"lat"] floatValue];
         longitude = [[latLng valueForKey:@"lng"] floatValue];
-        
+
         camera = [GMSCameraPosition cameraWithLatitude:latitude
                                             longitude:longitude
                                             zoom:[[cameraOpts valueForKey:@"zoom"] floatValue]
@@ -464,19 +470,19 @@
         scale = [[UIScreen mainScreen] scale];
       }
       [[UIScreen mainScreen] scale];
-      
+
       [self.mapCtrl.map moveCamera:[GMSCameraUpdate fitBounds:cameraBounds withPadding:10 * scale]];
       GMSCameraPosition *cameraPosition2 = [GMSCameraPosition cameraWithLatitude:cameraBounds.center.latitude
                                           longitude:cameraBounds.center.longitude
                                           zoom:self.mapCtrl.map.camera.zoom
                                           bearing:[[cameraOpts objectForKey:@"bearing"] doubleValue]
                                           viewingAngle:[[cameraOpts objectForKey:@"tilt"] doubleValue]];
-    
+
       [self.mapCtrl.map setCamera:cameraPosition2];
     }
 
   }
-  
+
   BOOL isEnabled = NO;
   //controls
   NSDictionary *controls = [initOptions objectForKey:@"controls"];
@@ -542,7 +548,7 @@
   //mapType
   NSString *typeStr = [initOptions valueForKey:@"mapType"];
   if (typeStr) {
-    
+
     NSDictionary *mapTypes = [NSDictionary dictionaryWithObjectsAndKeys:
                               ^() {return kGMSTypeHybrid; }, @"MAP_TYPE_HYBRID",
                               ^() {return kGMSTypeSatellite; }, @"MAP_TYPE_SATELLITE",
@@ -550,7 +556,7 @@
                               ^() {return kGMSTypeNormal; }, @"MAP_TYPE_NORMAL",
                               ^() {return kGMSTypeNone; }, @"MAP_TYPE_NONE",
                               nil];
-    
+
     typedef GMSMapViewType (^CaseBlock)();
     GMSMapViewType mapType;
     CaseBlock caseBlock = mapTypes[typeStr];
@@ -569,9 +575,9 @@
   float left = [[paddingJson objectForKey:@"left"] floatValue];
   float right = [[paddingJson objectForKey:@"right"] floatValue];
   float bottom = [[paddingJson objectForKey:@"bottom"] floatValue];
-  
+
   UIEdgeInsets padding = UIEdgeInsetsMake(top, left, bottom, right);
-  
+
   [self.mapCtrl.map setPadding:padding];
 }
 
@@ -582,26 +588,26 @@
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
   }
   GMSIndoorLevel *activeLevel = self.mapCtrl.map.indoorDisplay.activeLevel;
-  
+
   NSMutableDictionary *result = [NSMutableDictionary dictionary];
-  
+
   NSUInteger activeLevelIndex = [building.levels indexOfObject:activeLevel];
   [result setObject:[NSNumber numberWithInteger:activeLevelIndex] forKey:@"activeLevelIndex"];
   [result setObject:[NSNumber numberWithInteger:building.defaultLevelIndex] forKey:@"defaultLevelIndex"];
-  
+
   GMSIndoorLevel *level;
   NSMutableDictionary *levelInfo;
   NSMutableArray *levels = [NSMutableArray array];
   for (level in building.levels) {
     levelInfo = [NSMutableDictionary dictionary];
-    
+
     [levelInfo setObject:[NSString stringWithString:level.name] forKey:@"name"];
     [levelInfo setObject:[NSString stringWithString:level.shortName] forKey:@"shortName"];
     [levels addObject:levelInfo];
   }
   [result setObject:levels forKey:@"levels"];
-  
-  
+
+
   CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:result];
   [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }

--- a/src/ios/GoogleMaps/Marker.m
+++ b/src/ios/GoogleMaps/Marker.m
@@ -831,7 +831,12 @@
     } else if ([iconProperty valueForKey:@"iconColor"]) {
         UIColor *iconColor = [iconProperty valueForKey:@"iconColor"];
         marker.icon = [GMSMarker markerImageWithColor:iconColor];
-
+        
+        // The `visible` property
+        if ([[iconProperty valueForKey:@"visible"] boolValue]) {
+            marker.map = self.mapCtrl.map;
+        }
+        
         if (animation) {
             // Do animation, then send the result
             [self setMarkerAnimation_:animation marker:marker pluginResult:pluginResult callbackId:callbackId];

--- a/www/googlemaps-cdv-plugin.js
+++ b/www/googlemaps-cdv-plugin.js
@@ -584,6 +584,10 @@ App.prototype.setIndoorEnabled = function(enabled) {
     enabled = parseBoolean(enabled);
     cordova.exec(null, this.errorHandler, PLUGIN_NAME, 'exec', ['Map.setIndoorEnabled', enabled]);
 };
+App.prototype.setMapToolbarEnabled = function(enabled) {
+    enabled = parseBoolean(enabled);
+    cordova.exec(null, this.errorHandler, PLUGIN_NAME, 'exec', ['Map.setMapToolbarEnabled', enabled]);
+};
 App.prototype.setTrafficEnabled = function(enabled) {
     enabled = parseBoolean(enabled);
     cordova.exec(null, this.errorHandler, PLUGIN_NAME, 'exec', ['Map.setTrafficEnabled', enabled]);


### PR DESCRIPTION
This adds a setMapToolbarEnabled function, and a mapToolbar option during map initialization, to hide or show the [map toolbar](https://developers.google.com/maps/documentation/android-api/controls#map_toolbar) on Android devices. It also adds a stub so that calling the function on an iOS device won't result in an error.

Addresses #972.