### PR TITLE
Fixed json parameters for PointToLatLng

### DIFF
--- a/src/android/plugin/google/maps/PluginMap.java
+++ b/src/android/plugin/google/maps/PluginMap.java
@@ -591,8 +591,8 @@ public class PluginMap extends MyPlugin {
   @SuppressWarnings("unused")
   private void fromPointToLatLng(final JSONArray args, final CallbackContext callbackContext) throws JSONException {
     double pointX, pointY;
-    pointX = args.getDouble(0);
-    pointY = args.getDouble(1);
+    pointX = args.getDouble(1);
+    pointY = args.getDouble(2);
     final Point point = new Point();
     point.x = (int)(pointX * density);
     point.y = (int)(pointY * density);


### PR DESCRIPTION
This fix the parameters that are used in the function fromPointToLatLng() so the callback will be executed.  Otherwise an error message in the android logs will appear with

08-04 11:22:34.211: W/System.err(15840): Caused by: org.json.JSONException: Value Map.fromPointToLatLng at 0 of type java.lang.String cannot be converted to double
08-04 11:22:34.211: W/System.err(15840): at org.json.JSON.typeMismatch(JSON.java:100)
08-04 11:22:34.211: W/System.err(15840): at org.json.JSONArray.getDouble(JSONArray.java:353)
08-04 11:22:34.211: W/System.err(15840): at plugin.google.maps.PluginMap.fromPointToLatLng(PluginMap.java:594)

This has been reported in issue #1023