### PR TITLE
Call postExecute on callback to setIcon_ from AsyncTask.postExecute()

### DIFF
--- a/src/android/plugin/google/maps/PluginMarker.java
+++ b/src/android/plugin/google/maps/PluginMarker.java
@@ -735,13 +735,12 @@ public class PluginMarker extends MyPlugin {
               inputStream = assetManager.open(iconUrl);
               image = BitmapFactory.decodeStream(inputStream);
             } catch (IOException e) {
+              Log.w("GoogleMaps", "Unable to decode bitmap stream for icon " + iconUrl + ")");
               e.printStackTrace();
-              callback.onPostExecute(marker);
               return null;
             }
           }
           if (image == null) {
-            callback.onPostExecute(marker);
             return null;
           }
           


### PR DESCRIPTION
This patch moves some of the error handling from the doBackground() part of the AsyncTask in PluginMarker._setIcon() to the postExecute() part. This ensures that later Google maps interaction is on the UI thread instead of a background thread (which is not allowed and causes the application to crash).