### PR TITLE
Bugfix iOS portrait display when in landscape mode

### DIFF
--- a/src/ios/GoogleMaps/GoogleMaps.m
+++ b/src/ios/GoogleMaps/GoogleMaps.m
@@ -532,10 +532,13 @@
     // iOS8 or above
     direction = [UIDevice currentDevice].orientation;
 #endif
-
-
-    if (direction == UIInterfaceOrientationLandscapeLeft ||
-        direction == UIInterfaceOrientationLandscapeRight) {
+   
+   // On at least iOS 9.3.5, the screenSize.size changes on-orientation-change,
+   // so we need to check if we really need to use the height as width and vice versa,
+   // when in landscape mode.
+   if ((direction == UIInterfaceOrientationLandscapeLeft ||
+        direction == UIInterfaceOrientationLandscapeRight)
+       && screenSize.size.height > screenSize.size.width) {
         pluginRect.size.width = screenSize.size.height;
         pluginRect.size.height = screenSize.size.width - footerHeight - footerAdjustment;
     } else {


### PR DESCRIPTION
When my iPad, iOS 9.3.5, is in landscape mode, and I open the map, the map will show top-left, but only 768 px. wide, and without the footer and the Close button visible.
This also happens when rotating the device while the map is already visible.