### PR TITLE
add NSLocationWhenInUseUsageDescription to parent

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -194,7 +194,7 @@
         </config-file>
 
         <preference name="NSLocationWhenInUseUsageDescription" default="Show your location on the map" />
-        <config-file target="*-Info.plist" parent="">
+        <config-file target="*-Info.plist" parent="NSLocationWhenInUseUsageDescription">
             <string>$NSLocationWhenInUseUsageDescription</string>
         </config-file>
 


### PR DESCRIPTION
There was issue with cordova build command. That occured because of empty parent attribute of NSLocationWhenInUseUsageDescription