### PR TITLE
Fixed icon anchor moved in setInfoWindowAnchor

### DIFF
--- a/src/ios/GoogleMaps/Marker.m
+++ b/src/ios/GoogleMaps/Marker.m
@@ -285,7 +285,6 @@
     if (marker.icon) {
         anchorX = anchorX / marker.icon.size.width;
         anchorY = anchorY / marker.icon.size.height;
-        [marker setGroundAnchor:CGPointMake(anchorX, anchorY)];
     }
     [marker setInfoWindowAnchor:CGPointMake(anchorX, anchorY)];
 


### PR DESCRIPTION
setInfoWindowAnchor called setGroundAnchor, which causes some marker icons to be incorrectly anchored to the same anchor as the InfoWindow and "move around" as the user zooms in and out.

This call seems to be a copy & paste error and has now been removed.