### PR TITLE
Extra argument checks in getMap(div,params) function

### DIFF
--- a/www/googlemaps-cdv-plugin.js
+++ b/www/googlemaps-cdv-plugin.js
@@ -296,7 +296,14 @@ App.prototype.getMap = function(div, params) {
         args = [];
 
     if (!isDom(div)) {
-        params = div;
+		// check if div and params arguments are both given. If so, warn about !isDom(div)
+		if (div != null && params != null && isPlainObject(params)) {
+			return self.errorHandler("The [div] argument to function [getMap] is not a DOM element." +
+					"\nEither supply a valid DOM element with getMap(div,params) or only supply the [params] argument.");
+		// if only one argument was supplied, use the div value as params
+		} else if (div != null && params == null) {
+			params = div;
+		}
         params = params || {};
         params.backgroundColor = params.backgroundColor || '#ffffff';
         params.backgroundColor = HTMLColor2RGBA(params.backgroundColor);
@@ -2337,6 +2344,16 @@ function isDom(element) {
     return !!element &&
         typeof element === "object" &&
         "getBoundingClientRect" in element;
+}
+
+
+// Reference: http://stackoverflow.com/a/23441431/2783456
+// Make sure Object.getPrototypeOf exists
+Object.getPrototypeOf || (Object.getPrototypeOf=function(obj){
+	return obj.__proto__ || obj.prototype || (obj.constructor&&obj.constructor.prototype) || Object.prototype
+});
+function isPlainObject(obj) {
+	return obj != null && typeof(obj) == "object" && Object.getPrototypeOf(obj) == Object.prototype;
 }
 
 function getPageRect() {


### PR DESCRIPTION
Took me quite some time to debug the issue "'getMap' is not defined in GoogleMaps plugin". It's a general error if anything goes wrong inside the javascript getMap function.
In my case, I was supplying 2 arguments to the function, but the first one was a reference to a non-existing DOM element: a colleague had accidentally removed the element from the template :-(
This would have been no problem, if the line "if (!isDom(div)){... params = div; ...} " did not exist in the plugin code, or at least did some checking.
That's what this commit is for, some extra checks surrounding the incoming arguments.
