### PR TITLE
Avoid crashing if icon image is not found #1153

### DIFF
--- a/src/android/plugin/google/maps/PluginMarker.java
+++ b/src/android/plugin/google/maps/PluginMarker.java
@@ -162,7 +162,13 @@ public class PluginMarker extends MyPlugin {
           if (opts.has("visible")) {
             try {
               marker.setVisible(opts.getBoolean("visible"));
-            } catch (JSONException e) {}
+            } catch (Exception e) {
+              if(e instanceof JSONException) {}
+              if(e instanceof FileNotFoundException) {}
+              else {
+                e.printStackTrace();
+              }
+            }
           } else {
             marker.setVisible(true);
           }


### PR DESCRIPTION
App crashes due to FileNotFoundException and IllegalStateException if icon image is not found