### PR TITLE
Fix always zoom in animateCamera and moveCamera #14

### DIFF
--- a/src/android/plugin/google/maps/PluginMap.java
+++ b/src/android/plugin/google/maps/PluginMap.java
@@ -1241,12 +1241,12 @@ public class PluginMap extends MyPlugin implements OnMarkerClickListener,
           @SuppressWarnings("rawtypes")
           Class targetClass = target.getClass();
           JSONObject latLng;
-          if ("org.json.JSONArray".equals(targetClass.getName())) {
-            JSONArray points = cameraPos.getJSONArray("target");
+          JSONArray points = cameraPos.getJSONArray("target");
+          if (points.length() > 1) {
             result.cameraBounds = PluginUtil.JSONArray2LatLngBounds(points);
             result.cameraUpdate = CameraUpdateFactory.newLatLngBounds(result.cameraBounds, (int)(result.cameraPadding * density));
           } else {
-            latLng = cameraPos.getJSONObject("target");
+            latLng = (JSONObject)points.get(0);
             builder.target(new LatLng(latLng.getDouble("lat"), latLng.getDouble("lng")));
             newPosition = builder.build();
             result.cameraUpdate = CameraUpdateFactory.newCameraPosition(newPosition);


### PR DESCRIPTION
Alternative fix might be to change how we convert the argument in Map.js, this line is the underlying issue:
cameraPosition.target = common.convertToPositionArray(cameraPosition.target);

I didn't want to change Map.js because that could break something in iOS. I feel like this is a design choice of the plugin that you @wf9a5m75 are more suited to make. Feel free to throw away this PR and change Map.js if you feel that's a cleaner solution