### PR TITLE
Add ‘tappable’ option to overlays

### DIFF
--- a/src/android/plugin/google/maps/GoogleMaps.java
+++ b/src/android/plugin/google/maps/GoogleMaps.java
@@ -1433,23 +1433,26 @@ public class GoogleMaps extends CordovaPlugin implements View.OnClickListener, O
       for (HashMap.Entry<String, Object> entry : polylineClass.objects.entrySet()) {
         key = entry.getKey();
         if (key.contains("polyline_bounds_")) {
-          bounds = (LatLngBounds) entry.getValue();
-          if (bounds.contains(point)) {
-            key = key.replace("bounds_", "");
+          key = key.replace("bounds_", "");
+          if (polylineClass.isTappable(key)) {
+            bounds = (LatLngBounds) entry.getValue();
+            if (bounds.contains(point)) {
+              key = key.replace("bounds_", "");
 
-            polyline = polylineClass.getPolyline(key);
-            points = polyline.getPoints();
+              polyline = polylineClass.getPolyline(key);
+              points = polyline.getPoints();
 
-            if (polyline.isGeodesic()) {
-              if (this.isPointOnTheGeodesicLine(points, point, threshold)) {
-                hitPoly = true;
-                this.onPolylineClick(polyline, point);
-              }
-            } else {
+              if (polyline.isGeodesic()) {
+                if (this.isPointOnTheGeodesicLine(points, point, threshold)) {
+                  hitPoly = true;
+                  this.onPolylineClick(polyline, point);
+                }
+              } else {
                 if (this.isPointOnTheLine(points, point)) {
                   hitPoly = true;
                   this.onPolylineClick(polyline, point);
                 }
+              }
             }
           }
         }
@@ -1467,15 +1470,16 @@ public class GoogleMaps extends CordovaPlugin implements View.OnClickListener, O
       for (HashMap.Entry<String, Object> entry : polygonClass.objects.entrySet()) {
         key = entry.getKey();
         if (key.contains("polygon_bounds_")) {
-          bounds = (LatLngBounds) entry.getValue();
-          if (bounds.contains(point)) {
+          key = key.replace("_bounds", "");
+          if (polygonClass.isTappable(key)) {
+            bounds = (LatLngBounds) entry.getValue();
+            if (bounds.contains(point)) {
+              Polygon polygon = polygonClass.getPolygon(key);
 
-            key = key.replace("_bounds", "");
-            Polygon polygon = polygonClass.getPolygon(key);
-
-            if (this.isPolygonContains(polygon.getPoints(), point)) {
-              hitPoly = true;
-              this.onPolygonClick(polygon, point);
+              if (this.isPolygonContains(polygon.getPoints(), point)) {
+                hitPoly = true;
+                this.onPolygonClick(polygon, point);
+              }
             }
           }
         }
@@ -1492,9 +1496,11 @@ public class GoogleMaps extends CordovaPlugin implements View.OnClickListener, O
 
       for (HashMap.Entry<String, Object> entry : circleClass.objects.entrySet()) {
         Circle circle = (Circle) entry.getValue();
-        if (this.isCircleContains(circle, point)) {
-          hitPoly = true;
-          this.onCircleClick(circle, point);
+        if (circleClass.isTappable(entry.getKey())) {
+          if (this.isCircleContains(circle, point)) {
+            hitPoly = true;
+            this.onCircleClick(circle, point);
+          }
         }
       }
       if (hitPoly) {
@@ -1510,10 +1516,12 @@ public class GoogleMaps extends CordovaPlugin implements View.OnClickListener, O
       for (HashMap.Entry<String, Object> entry : groundOverlayClass.objects.entrySet()) {
         key = entry.getKey();
         if (key.contains("groundOverlay_")) {
-          GroundOverlay groundOverlay = (GroundOverlay) entry.getValue();
-          if (this.isGroundOverlayContains(groundOverlay, point)) {
-            hitPoly = true;
-            this.onGroundOverlayClick(groundOverlay, point);
+          if (groundOverlayClass.isTappable(key)) {
+            GroundOverlay groundOverlay = (GroundOverlay) entry.getValue();
+            if (this.isGroundOverlayContains(groundOverlay, point)) {
+              hitPoly = true;
+              this.onGroundOverlayClick(groundOverlay, point);
+            }
           }
         }
       }

--- a/src/android/plugin/google/maps/MyPlugin.java
+++ b/src/android/plugin/google/maps/MyPlugin.java
@@ -24,6 +24,7 @@ import com.google.android.gms.maps.model.TileOverlay;
 
 public class MyPlugin extends CordovaPlugin implements MyPluginInterface  {
   protected HashMap<String, Object> objects;
+  protected HashMap<String, Boolean> tappables;
 
   public GoogleMaps mapCtrl = null;
   public GoogleMap map = null;
@@ -39,6 +40,7 @@ public class MyPlugin extends CordovaPlugin implements MyPluginInterface  {
   public void initialize(CordovaInterface cordova, final CordovaWebView webView) {
     super.initialize(cordova, webView);
     this.objects = new HashMap<String, Object>();
+    this.tappables = new HashMap<String, Boolean>();
   }
   @Override
   public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
@@ -55,6 +57,10 @@ public class MyPlugin extends CordovaPlugin implements MyPluginInterface  {
     }
   }
   
+  protected boolean isTappable(String id) {
+    return this.tappables.containsKey(id);
+  }
+
   protected Circle getCircle(String id) {
     return (Circle)this.objects.get(id);
   }

--- a/src/android/plugin/google/maps/PluginCircle.java
+++ b/src/android/plugin/google/maps/PluginCircle.java
@@ -51,6 +51,10 @@ public class PluginCircle extends MyPlugin  {
     String id = "circle_" + circle.getId();
     this.objects.put(id, circle);
     
+    if (opts.has("tappable") && opts.getBoolean("tappable")) {
+      this.tappables.put(id, true);
+    }
+
     JSONObject result = new JSONObject();
     result.put("hashCode", circle.hashCode());
     result.put("id", id);
@@ -166,6 +170,7 @@ public class PluginCircle extends MyPlugin  {
     }
     circle.remove();
     this.objects.remove(id);
+    this.tappables.remove(id);
     this.sendNoResult(callbackContext);
   }
 }

--- a/src/android/plugin/google/maps/PluginGroundOverlay.java
+++ b/src/android/plugin/google/maps/PluginGroundOverlay.java
@@ -61,6 +61,8 @@ public class PluginGroundOverlay extends MyPlugin {
       options.positionFromBounds(bounds);
     }
 
+    final boolean tappable = opts.has("tappable") && opts.getBoolean("tappable");
+
     // Load image
     String url = opts.getString("url");
     _setImage(url, options, new PluginAsyncInterface() {
@@ -71,6 +73,10 @@ public class PluginGroundOverlay extends MyPlugin {
 
         String id = "groundOverlay_" + groundOverlay.getId();
         PluginGroundOverlay.this.objects.put(id, groundOverlay);
+
+        if (tappable) {
+          PluginGroundOverlay.this.tappables.put(id, true);
+        }
 
         JSONObject result = new JSONObject();
         try {
@@ -202,6 +208,11 @@ public class PluginGroundOverlay extends MyPlugin {
       this.sendNoResult(callbackContext);
       return;
     }
+
+    // FIXME should this function also remove the overlay from this.objects?
+    // this.objects.remove(id);
+
+    this.tappables.remove(id);
 
     String propertyId = "gOverlay_property_" + id;
     this.objects.remove(propertyId);

--- a/src/android/plugin/google/maps/PluginPolygon.java
+++ b/src/android/plugin/google/maps/PluginPolygon.java
@@ -73,6 +73,10 @@ public class PluginPolygon extends MyPlugin implements MyPluginInterface  {
         String id = "polygon_"+ polygon.getId();
         this.objects.put(id, polygon);
 
+        if (opts.has("tappable") && opts.getBoolean("tappable")) {
+          this.tappables.put(id, true);
+        }
+
         String boundsId = "polygon_bounds_" + polygon.getId();
         this.objects.put(boundsId, builder.build());
 
@@ -163,6 +167,7 @@ public class PluginPolygon extends MyPlugin implements MyPluginInterface  {
             return;
         }
         this.objects.remove(id);
+        this.tappables.remove(id);
 
         id = "polygon_bounds_" + polygon.getId();
         this.objects.remove(id);

--- a/src/android/plugin/google/maps/PluginPolyline.java
+++ b/src/android/plugin/google/maps/PluginPolyline.java
@@ -59,6 +59,10 @@ public class PluginPolyline extends MyPlugin implements MyPluginInterface  {
     String id = "polyline_" + polyline.getId();
     this.objects.put(id, polyline);
 
+    if (opts.has("tappable") && opts.getBoolean("tappable")) {
+      this.tappables.put(id, true);
+    }
+
     String boundsId = "polyline_bounds_" + polyline.getId();
     this.objects.put(boundsId, builder.build());
     
@@ -223,6 +227,7 @@ public class PluginPolyline extends MyPlugin implements MyPluginInterface  {
       return;
     }
     this.objects.remove(id);
+    this.tappables.remove(id);
     
     id = "polyline_bounds_" + polyline.getId();
     this.objects.remove(id);

--- a/src/ios/GoogleMaps/Circle.m
+++ b/src/ios/GoogleMaps/Circle.m
@@ -37,8 +37,13 @@
   circle.strokeWidth = [[json valueForKey:@"strokeWidth"] floatValue];
   circle.zIndex = [[json valueForKey:@"zIndex"] floatValue];
 
-  circle.tappable = YES;
-  
+  if ([[json valueForKey:@"tappable"] boolValue]) {
+    circle.tappable = YES;
+  }
+  else {
+    circle.tappable = NO;
+  }
+
   NSString *id = [NSString stringWithFormat:@"circle_%lu", (unsigned long)circle.hash];
   [self.mapCtrl.overlayManager setObject:circle forKey: id];
   circle.title = id;

--- a/src/ios/GoogleMaps/GroundOverlay.m
+++ b/src/ios/GoogleMaps/GroundOverlay.m
@@ -56,7 +56,12 @@
             layer.bearing = [[json valueForKey:@"bearing"] floatValue];
         }
 
-        layer.tappable = YES;
+        if ([[json valueForKey:@"tappable"] boolValue]) {
+          layer.tappable = YES;
+        }
+        else {
+          layer.tappable = NO;
+        }
 
         NSString *id = [NSString stringWithFormat:@"groundOverlay_%lu", (unsigned long)layer.hash];
         [self_.mapCtrl.overlayManager setObject:layer forKey: id];

--- a/src/ios/GoogleMaps/Polygon.m
+++ b/src/ios/GoogleMaps/Polygon.m
@@ -67,7 +67,12 @@
   polygon.strokeWidth = [[json valueForKey:@"strokeWidth"] floatValue];
   polygon.zIndex = [[json valueForKey:@"zIndex"] floatValue];
     
-  polygon.tappable = YES;
+  if ([[json valueForKey:@"tappable"] boolValue]) {
+    polygon.tappable = YES;
+  }
+  else {
+    polygon.tappable = NO;
+  }
 
   NSString *id = [NSString stringWithFormat:@"polygon_%lu", (unsigned long)polygon.hash];
   [self.mapCtrl.overlayManager setObject:polygon forKey: id];

--- a/src/ios/GoogleMaps/Polyline.m
+++ b/src/ios/GoogleMaps/Polyline.m
@@ -43,8 +43,13 @@
   polyline.strokeWidth = [[json valueForKey:@"width"] floatValue];
   polyline.zIndex = [[json valueForKey:@"zIndex"] floatValue];
 
-  polyline.tappable = YES;
-  
+  if ([[json valueForKey:@"tappable"] boolValue]) {
+    polyline.tappable = YES;
+  }
+  else {
+    polyline.tappable = NO;
+  }
+
   NSString *id = [NSString stringWithFormat:@"polyline_%lu", (unsigned long)polyline.hash];
   [self.mapCtrl.overlayManager setObject:polyline forKey: id];
   polyline.title = id;

--- a/www/googlemaps-cdv-plugin.js
+++ b/www/googlemaps-cdv-plugin.js
@@ -1100,6 +1100,7 @@ App.prototype.addCircle = function(circleOptions, callback) {
     circleOptions.visible = circleOptions.visible === undefined ? true : circleOptions.visible;
     circleOptions.zIndex = circleOptions.zIndex || 3;
     circleOptions.radius = circleOptions.radius || 1;
+    circleOptions.tappable = circleOptions.tappable === undefined ? true : circleOptions.tappable;
 
     cordova.exec(function(result) {
         var circle = new Circle(self, result.id, circleOptions);
@@ -1123,6 +1124,7 @@ App.prototype.addPolyline = function(polylineOptions, callback) {
     polylineOptions.visible = polylineOptions.visible === undefined ? true : polylineOptions.visible;
     polylineOptions.zIndex = polylineOptions.zIndex || 4;
     polylineOptions.geodesic = polylineOptions.geodesic  === true;
+    polylineOptions.tappable = polylineOptions.tappable === undefined ? true : polylineOptions.tappable;
 
     cordova.exec(function(result) {
         var polyline = new Polyline(self, result.id, polylineOptions);
@@ -1161,6 +1163,7 @@ App.prototype.addPolygon = function(polygonOptions, callback) {
     polygonOptions.visible = polygonOptions.visible === undefined ? true : polygonOptions.visible;
     polygonOptions.zIndex = polygonOptions.zIndex || 2;
     polygonOptions.geodesic = polygonOptions.geodesic  === true;
+    polygonOptions.tappable    = polygonOptions.tappable === undefined ? true : polygonOptions.tappable;
 
     cordova.exec(function(result) {
         var polygon = new Polygon(self, result.id, polygonOptions);
@@ -1212,6 +1215,7 @@ App.prototype.addGroundOverlay = function(groundOverlayOptions, callback) {
     groundOverlayOptions.visible = groundOverlayOptions.visible === undefined ? true : groundOverlayOptions.visible;
     groundOverlayOptions.zIndex = groundOverlayOptions.zIndex || 1;
     groundOverlayOptions.bounds = groundOverlayOptions.bounds || [];
+    groundOverlayOptions.tappable = groundOverlayOptions.tappable === undefined ? true : groundOverlayOptions.tappable;
 
     cordova.exec(function(result) {
         var groundOverlay = new GroundOverlay(self, result.id, groundOverlayOptions);


### PR DESCRIPTION
Uses native "tappable" on iOS, and uses custom one on Android by adding a "tappables" hashmap to `MyPlugin` and keeps track of which overlays should be added.