### PR TITLE
Corrected parameters in call to removeObjectForKey

### DIFF
--- a/src/ios/GoogleMaps/MyPluginLayer.m
+++ b/src/ios/GoogleMaps/MyPluginLayer.m
@@ -142,7 +142,7 @@ BOOL hasCordovaStatusBar = NO;  // YES if the app has cordova-plugin-statusbar
   dispatch_async(dispatch_get_main_queue(), ^{
   
       // Remove the mapCtrl instance with mapId.
-      [self.pluginScrollView.debugView.mapCtrls removeObjectForKey:mapCtrl];
+      [self.pluginScrollView.debugView.mapCtrls removeObjectForKey:mapCtrl.mapId];
       
       // Remove the mapView from the scroll view.
       [mapCtrl.view removeFromSuperview];


### PR DESCRIPTION
The keys in mapCtrls are mapIds, not mapCtrl objects.

This fix means that when iOS maps are removed, they are actually removed, as before, they were not.

This caused issues when placing a map in a div which previously contained a map which had since been removed. This was because the plugin would pass any touch events on the new map to the old (removed) map.