### PR TITLE
feature(map settings): hide map toolbar

### DIFF
--- a/src/android/plugin/google/maps/GoogleMaps.java
+++ b/src/android/plugin/google/maps/GoogleMaps.java
@@ -481,6 +481,9 @@ public class GoogleMaps extends CordovaPlugin implements View.OnClickListener, O
       if (controls.has("zoom")) {
         options.zoomControlsEnabled(controls.getBoolean("zoom"));
       }
+      if (controls.has("mapToolbar")) {
+        options.mapToolbarEnabled(controls.getBoolean("mapToolbar"));
+      }
     }
 
     //gestures


### PR DESCRIPTION
Adding option for hide toolbar when marker is clicked. Solves issue https://github.com/mapsplugin/cordova-plugin-googlemaps/issues/1295 for plugin v 1.4.0.

Plugin v2 already supports this, but unfortunately without support of crosswalk...