### PR TITLE
Solving the memory leak

### DIFF
--- a/src/android/plugin/google/maps/PluginMap.java
+++ b/src/android/plugin/google/maps/PluginMap.java
@@ -667,6 +667,9 @@ public class PluginMap extends MyPlugin implements OnMarkerClickListener,
               PluginEntry pluginEntry;
               for (int i = 0; i < pluginNames.length; i++) {
                 pluginEntry = plugins.remove(pluginNames[i]);
+                ((MyPlugin)pluginEntry.plugin).map = null;
+                ((MyPlugin)pluginEntry.plugin).mapCtrl = null;
+                ((MyPlugin)pluginEntry.plugin).pluginMap = null;
                 pluginEntry.plugin.onDestroy();
                 pluginEntry = null;
               }

--- a/src/android/plugin/google/maps/PluginMarker.java
+++ b/src/android/plugin/google/maps/PluginMarker.java
@@ -950,7 +950,7 @@ public class PluginMarker extends MyPlugin implements MyPluginInterface  {
             try {
               inputStream = assetManager.open(iconUrl);
               image = BitmapFactory.decodeStream(inputStream);
-              inputStream.close()
+              inputStream.close();
             } catch (IOException e) {
               e.printStackTrace();
               return null;

--- a/src/android/plugin/google/maps/PluginMarker.java
+++ b/src/android/plugin/google/maps/PluginMarker.java
@@ -94,11 +94,11 @@ public class PluginMarker extends MyPlugin implements MyPluginInterface  {
     cordova.getThreadPool().submit(new Runnable() {
       @Override
       public void run() {
-        AsyncLoadImage[] tasks = iconLoadingTasks.toArray(new AsyncLoadImage[iconLoadingTasks.size()]);
-        for (int i = 0; i < tasks.length; i++) {
-          tasks[i].cancel(true);
+        for (int i = 0, ilen=iconLoadingTasks.size(); i < ilen; i++) {
+          iconLoadingTasks.get(i).cancel(true);
+          iconLoadingTasks.set(i, null);
         }
-        iconLoadingTasks.clear();
+        iconLoadingTasks = null;
       }
     });
 

--- a/src/android/plugin/google/maps/PluginMarker.java
+++ b/src/android/plugin/google/maps/PluginMarker.java
@@ -950,6 +950,7 @@ public class PluginMarker extends MyPlugin implements MyPluginInterface  {
             try {
               inputStream = assetManager.open(iconUrl);
               image = BitmapFactory.decodeStream(inputStream);
+              inputStream.close()
             } catch (IOException e) {
               e.printStackTrace();
               return null;
@@ -958,8 +959,6 @@ public class PluginMarker extends MyPlugin implements MyPluginInterface  {
           if (image == null) {
             return null;
           }
-          icons.add(image);
-
           Boolean isResized = false;
           if (iconProperty.containsKey("size")) {
             Object size = iconProperty.get("size");


### PR DESCRIPTION
Removing the memory leak by explicitly setting null to some persistent references. 
Covered following method: 
- Map.destroy()

Not covered:
- Map.clear()
- Marker.destroy()

So to be explicit:
- With this patch, If the map is destroyed, all the allocated memory is fully released.
- However, all others elements destruction/clear method (eg: a marker removal) will leak memory (at least until the map is destroyed). To cover/resolve this, you need to apply the same "kind" of patch i did on map.destroy() to others elements.