### PR TITLE
fix(map): fixes issue with invalid string length when options.styles is specified

### DIFF
--- a/www/Map.js
+++ b/www/Map.js
@@ -119,7 +119,7 @@ Map.prototype.getMap = function(mapId, div, options) {
             this.set('camera_tilt', options.camera.tilt);
           }
         }
-        if (options.styles) {
+        if (utils.isArray(options.styles)) {
           options.styles = JSON.stringify(options.styles);
         }
         args.push(options);
@@ -197,7 +197,7 @@ Map.prototype.setOptions = function(options) {
         this.set('camera_tilt', options.camera.tilt);
       }
     }
-    if (options.styles) {
+    if (utils.isArray(options.styles)) {
       options.styles = JSON.stringify(options.styles);
     }
     exec(null, this.errorHandler, this.id, 'setOptions', [options]);


### PR DESCRIPTION
when you specify `options.styles` for the map the they are converted several times into `JSON` and eventually JS code raises exception `Invalid string length`. The bug is produced because code changes passed in `options` argument instead of making a copy of `options` and change a copy.
 (https://github.com/mapsplugin/cordova-plugin-googlemaps/blob/multiple_maps/www/Map.js#L123)

This is hot fix which checks that `options.styles` is array and only then converts it into JSON