### PR TITLE
fix(browserify): removes `return` statement which was used outside of function scope

### DIFF
--- a/www/googlemaps-cdv-plugin.js
+++ b/www/googlemaps-cdv-plugin.js
@@ -1,9 +1,5 @@
 /* global cordova, plugin, CSSPrimitiveValue */
 var MAP_CNT = 0;
-
-if (!cordova) {
-  return;
-}
 var argscheck = require('cordova/argscheck'),
     utils = require('cordova/utils'),
     cordova_exec = require('cordova/exec'),


### PR DESCRIPTION
This fixes `cordova build --browserify` build and allows to improve app boot time significantly!

Fixes #1616