### PR TITLE
Fixes iOS 11 white statusbar issue in Cordova

### DIFF
--- a/www/googlemaps-cdv-plugin.js
+++ b/www/googlemaps-cdv-plugin.js
@@ -59,7 +59,7 @@ if (!cordova) {
         viewportTag = document.createElement("meta");
         viewportTag.setAttribute('name', 'viewport');
     }
-    viewportTag.setAttribute('content', 'width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no');
+    viewportTag.setAttribute('content', 'width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, viewport-fit=cover');
   })();
 
   /*****************************************************************************


### PR DESCRIPTION
iOS 11 changes the behaviour of how UIWebView and WKWebView calculates the layout. 

<iOS 11 it would return the layout including the status bar so you could render underneath it. 
In IOS 11 by default the layout no longer includes the status bar (which is then rendered as white).

As the Cordova team has suggested, you can add a viewport tag ```viewport-fit=cover``` to change to the intended behaviour of including the status bar. https://issues.apache.org/jira/browse/CB-12886

However this plugin overrides the viewport tag on load with its own custom value. This corrects the value to also include the fix.