### PR TITLE
error loading in external maps

### DIFF
--- a/www/LatLng.js
+++ b/www/LatLng.js
@@ -34,7 +34,7 @@ LatLng.prototype = {
    * @return {String} latitude,lontitude
    */
   toString: function() {
-    return '{"lat": ' + this.lat + ', "lng": ' + this.lng + '}';
+    return '{ ' + this.lat + ', ' + this.lng + '}';
   },
 
   /**
@@ -44,7 +44,7 @@ LatLng.prototype = {
    */
   toUrlValue: function(precision) {
     precision = precision || 6;
-    return '{"lat": ' + this.lat.toFixed(precision) + ', "lng": ' + this.lng.toFixed(precision) + '}';
+    return '{ ' + this.lat.toFixed(precision) + ', ' + this.lng.toFixed(precision) + '}';
   }
 };
 


### PR DESCRIPTION
The map was loading latlng as {"lat":xxx,"lng":xxx) and saying location could not be found.  Removed "lat","lng"