### PR TITLE
fix: overlays click not working in iOS

### DIFF
--- a/src/ios/GoogleMaps/PluginCircle.m
+++ b/src/ios/GoogleMaps/PluginCircle.m
@@ -92,7 +92,8 @@
         circle.tappable = NO;
 
         // Store the circle instance into self.objects
-        NSString *circleId = [NSString stringWithFormat:@"circle_%lu%d", command.hash, arc4random() % 100000];
+        NSString *idBase = [NSString stringWithFormat:@"%lu%d", command.hash, arc4random() % 100000];
+        NSString *circleId = [NSString stringWithFormat:@"circle_%@", idBase];
         circle.title = circleId;
         [self.mapCtrl.objects setObject:circle forKey: circleId];
 
@@ -101,7 +102,7 @@
             //---------------------------
             // Keep the properties
             //---------------------------
-            NSString *propertyId = [NSString stringWithFormat:@"circle_property_%lu", (unsigned long)circle.hash];
+            NSString *propertyId = [NSString stringWithFormat:@"circle_property_%@", idBase];
 
             // points
             NSMutableDictionary *properties = [[NSMutableDictionary alloc] init];

--- a/src/ios/GoogleMaps/PluginGroundOverlay.m
+++ b/src/ios/GoogleMaps/PluginGroundOverlay.m
@@ -80,7 +80,8 @@
     dispatch_async(dispatch_get_main_queue(), ^{
         GMSGroundOverlay *groundOverlay = [GMSGroundOverlay groundOverlayWithBounds:bounds icon:nil];
 
-        NSString *groundOverlayId = [NSString stringWithFormat:@"groundoverlay_%lu%d", command.hash, arc4random() % 100000];
+        NSString *idBase = [NSString stringWithFormat:@"%lu%d", command.hash, arc4random() % 100000];
+        NSString *groundOverlayId = [NSString stringWithFormat:@"groundoverlay_%@", idBase];
         [self.mapCtrl.objects setObject:groundOverlay forKey: groundOverlayId];
         groundOverlay.title = groundOverlayId;
 
@@ -132,7 +133,7 @@
                   //---------------------------
                   // Keep the properties
                   //---------------------------
-                  NSString *propertyId = [NSString stringWithFormat:@"groundoverlay_property_%lu", (unsigned long)groundOverlay.hash];
+                  NSString *propertyId = [NSString stringWithFormat:@"groundoverlay_property_%@", idBase];
 
                   // points
                   NSMutableDictionary *properties = [[NSMutableDictionary alloc] init];

--- a/src/ios/GoogleMaps/PluginPolygon.m
+++ b/src/ios/GoogleMaps/PluginPolygon.m
@@ -120,7 +120,8 @@
       polygon.tappable = NO;
 
       // Register polygon to the overlayManager.
-      NSString *id = [NSString stringWithFormat:@"polygon_%lu%d", command.hash, arc4random() % 100000];
+      NSString *idBase = [NSString stringWithFormat:@"%lu%d", command.hash, arc4random() % 100000];
+      NSString *id = [NSString stringWithFormat:@"polygon_%@", idBase];
       [self.mapCtrl.objects setObject:polygon forKey: id];
       polygon.title = id;
 
@@ -130,7 +131,7 @@
           //---------------------------
           // Keep the properties
           //---------------------------
-          NSString *propertyId = [NSString stringWithFormat:@"polygon_property_%lu", (unsigned long)polygon.hash];
+          NSString *propertyId = [NSString stringWithFormat:@"polygon_property_%@", idBase];
 
           // points
           NSMutableDictionary *properties = [[NSMutableDictionary alloc] init];

--- a/src/ios/GoogleMaps/PluginPolyline.m
+++ b/src/ios/GoogleMaps/PluginPolyline.m
@@ -96,7 +96,8 @@
       // disable default clickable feature.
       polyline.tappable = NO;
 
-      NSString *id = [NSString stringWithFormat:@"polyline_%lu%d", command.hash, arc4random() % 100000];
+      NSString *idBase = [NSString stringWithFormat:@"%lu%d", command.hash, arc4random() % 100000];
+      NSString *id = [NSString stringWithFormat:@"polyline_%@", idBase];
       [self.mapCtrl.objects setObject:polyline forKey: id];
       polyline.title = id;
 
@@ -112,7 +113,7 @@
           //---------------------------
           // Keep the properties
           //---------------------------
-          NSString *propertyId = [NSString stringWithFormat:@"polyline_property_%lu", (unsigned long)polyline.hash];
+          NSString *propertyId = [NSString stringWithFormat:@"polyline_property_%@", idBase];
 
           // points
           NSMutableDictionary *properties = [[NSMutableDictionary alloc] init];


### PR DESCRIPTION
overlay object was not found when clicking because overlay and its property ids are generated in different ways.