### PR TITLE
fix define var `self` in `remove` method of overlays

### DIFF
--- a/www/Circle.js
+++ b/www/Circle.js
@@ -143,9 +143,10 @@ Circle.prototype.setRadius = function(radius) {
 };
 
 Circle.prototype.remove = function() {
+    var self = this;
     this.trigger(this.id + "_remove");
     exec.call(this, null, this.errorHandler, this.getPluginName(), 'remove', [this.getId()]);
-    Object.defineProperty(this, "_isRemoved", {
+    Object.defineProperty(self, "_isRemoved", {
         value: true,
         writable: false
     });

--- a/www/Circle.js
+++ b/www/Circle.js
@@ -145,7 +145,7 @@ Circle.prototype.setRadius = function(radius) {
 Circle.prototype.remove = function() {
     this.trigger(this.id + "_remove");
     exec.call(this, null, this.errorHandler, this.getPluginName(), 'remove', [this.getId()]);
-    Object.defineProperty(self, "_isRemoved", {
+    Object.defineProperty(this, "_isRemoved", {
         value: true,
         writable: false
     });

--- a/www/GroundOverlay.js
+++ b/www/GroundOverlay.js
@@ -146,9 +146,10 @@ GroundOverlay.prototype.getClickable = function() {
 };
 
 GroundOverlay.prototype.remove = function() {
+    var self = this;
     this.trigger(this.id + "_remove");
     exec.call(this, null, this.errorHandler, this.getPluginName(), 'remove', [this.getId()]);
-    Object.defineProperty(this, "_isRemoved", {
+    Object.defineProperty(self, "_isRemoved", {
         value: true,
         writable: false
     });

--- a/www/GroundOverlay.js
+++ b/www/GroundOverlay.js
@@ -148,7 +148,7 @@ GroundOverlay.prototype.getClickable = function() {
 GroundOverlay.prototype.remove = function() {
     this.trigger(this.id + "_remove");
     exec.call(this, null, this.errorHandler, this.getPluginName(), 'remove', [this.getId()]);
-    Object.defineProperty(self, "_isRemoved", {
+    Object.defineProperty(this, "_isRemoved", {
         value: true,
         writable: false
     });

--- a/www/Polygon.js
+++ b/www/Polygon.js
@@ -127,9 +127,10 @@ var Polygon = function(map, polygonId, polygonOptions, _exec) {
 utils.extend(Polygon, BaseClass);
 
 Polygon.prototype.remove = function() {
+    var self = this;
     this.trigger(this.id + "_remove");
     exec.call(this, null, this.errorHandler, this.getPluginName(), 'remove', [this.getId()]);
-    Object.defineProperty(this, "_isRemoved", {
+    Object.defineProperty(self, "_isRemoved", {
         value: true,
         writable: false
     });

--- a/www/Polygon.js
+++ b/www/Polygon.js
@@ -129,7 +129,7 @@ utils.extend(Polygon, BaseClass);
 Polygon.prototype.remove = function() {
     this.trigger(this.id + "_remove");
     exec.call(this, null, this.errorHandler, this.getPluginName(), 'remove', [this.getId()]);
-    Object.defineProperty(self, "_isRemoved", {
+    Object.defineProperty(this, "_isRemoved", {
         value: true,
         writable: false
     });

--- a/www/Polyline.js
+++ b/www/Polyline.js
@@ -166,13 +166,14 @@ Polyline.prototype.getMap = function() {
 };
 
 Polyline.prototype.remove = function() {
+    var self = this;
     exec.call(this, null, this.errorHandler, this.getPluginName(), 'remove', [this.getId()]);
     this.trigger(this.id + "_remove");
     var points = this.get("points");
     if (points) {
       points.clear();
     }
-    Object.defineProperty(this, "_isRemoved", {
+    Object.defineProperty(self, "_isRemoved", {
         value: true,
         writable: false
     });

--- a/www/Polyline.js
+++ b/www/Polyline.js
@@ -172,7 +172,7 @@ Polyline.prototype.remove = function() {
     if (points) {
       points.clear();
     }
-    Object.defineProperty(self, "_isRemoved", {
+    Object.defineProperty(this, "_isRemoved", {
         value: true,
         writable: false
     });

--- a/www/TileOverlay.js
+++ b/www/TileOverlay.js
@@ -107,9 +107,10 @@ TileOverlay.prototype.getVisible = function() {
 };
 
 TileOverlay.prototype.remove = function() {
+    var self = this;
     this.trigger(this.id + "_remove");
     exec.call(this, null, this.errorHandler, this.getPluginName(), 'remove', [this.getId()]);
-    Object.defineProperty(this, "_isRemoved", {
+    Object.defineProperty(self, "_isRemoved", {
         value: true,
         writable: false
     });

--- a/www/TileOverlay.js
+++ b/www/TileOverlay.js
@@ -109,7 +109,7 @@ TileOverlay.prototype.getVisible = function() {
 TileOverlay.prototype.remove = function() {
     this.trigger(this.id + "_remove");
     exec.call(this, null, this.errorHandler, this.getPluginName(), 'remove', [this.getId()]);
-    Object.defineProperty(self, "_isRemoved", {
+    Object.defineProperty(this, "_isRemoved", {
         value: true,
         writable: false
     });


### PR DESCRIPTION
there are times when native code not called when removing map.  
I could not catch up to details, but I guessed this to be the cause.  
by the way, `self` refers to `window`.