### PR TITLE
Add clickZoom to MarkerClusterOptions

### DIFF
--- a/www/Map.js
+++ b/www/Map.js
@@ -1414,7 +1414,8 @@ Map.prototype.addMarkerCluster = function(markerClusterOptions, callback) {
       "markerMap": markerMap,
       "maxZoomLevel": Math.min(markerClusterOptions.maxZoomLevel || 15, 18),
       "debug": markerClusterOptions.debug === true,
-      "boundsDraw": common.defaultTrueOption(markerClusterOptions.boundsDraw)
+      "boundsDraw": common.defaultTrueOption(markerClusterOptions.boundsDraw),
+      "clickZoom": common.defaultTrueOption(markerClusterOptions.clickZoom)
     }, exec);
     markerCluster.one("remove", function() {
       delete self.OVERLAYS[result.id];

--- a/www/Map.js
+++ b/www/Map.js
@@ -1487,7 +1487,7 @@ Map.prototype._onClusterEvent = function(eventName, markerClusterId, clusterId, 
       if (/^marker_/i.test(clusterId)) {
         // regular marker
         var marker = markerCluster.getMarkerById(clusterId);
-        if (eventName === event.MARKER_CLICK) {
+        if (eventName === event.MARKER_CLICK || eventName === event.INFO_CLICK) {
           markerCluster.trigger(eventName, position, marker);
         } else {
           if (eventName === event.INFO_OPEN) {

--- a/www/MarkerCluster.js
+++ b/www/MarkerCluster.js
@@ -89,6 +89,10 @@ var MarkerCluster = function(map, markerClusterId, markerClusterOptions, _exec) 
       self.set("polygon", polygon);
     });
   }
+  Object.defineProperty(self, "clickZoom", {
+    value: markerClusterOptions.clickZoom === true,
+    writable: false
+  });
   self.taskQueue = [];
   self._stopRequest = false;
   self._isWorking = false;
@@ -219,7 +223,7 @@ MarkerCluster.prototype.getHashCode = function() {
 };
 
 MarkerCluster.prototype.onClusterClicked = function(cluster) {
-  if (this._isRemoved) {
+  if (this._isRemoved || !this.clickZoom) {
     return null;
   }
   var self = this;


### PR DESCRIPTION
Added clickZoom boolean property to MarkerClusterOptions, similar to the ZoomOnClick property of Google's markerclustererplus. Defaults to true, so default behavior is unchanged.

If setting to false, one can use the 'cluster_click' event to decide if/when and how to zoom on cluster clicks.
