### PR TITLE
Use console.error instead of displaying an alert

### DIFF
--- a/www/googlemaps-cdv-plugin.js
+++ b/www/googlemaps-cdv-plugin.js
@@ -675,10 +675,10 @@ if (!cordova) {
           if (/Android/i.test(window.navigator.userAgent)) {
               //------------------------------------------------------------------------
               // If Google Maps Android API v2 is not available,
-              // display the warning alert.
+              // display the error.
               //------------------------------------------------------------------------
               cordova.exec(null, function(message) {
-                  alert(message);
+                  console.error(message);
               }, 'Environment', 'isAvailable', ['']);
           }
       }, {


### PR DESCRIPTION
When having a code base for an app that can run both in the browser and on android, it might not be that easy to exclude this plugin while maintaining an easy codebase/build system.

So if the plugin fails to initialize, it might still make sense to use the application without showing errors directly to the user. Therefore I suggest to replace the very intruding alert, by a more silent `console.error`, so the UX is not directly affected by the error.