### PR TITLE
Fix #2091 apostrophe which break on AAPT linux during 'cordova run'

### DIFF
--- a/src/android/res/values-uk/pgm_strings.xml
+++ b/src/android/res/values-uk/pgm_strings.xml
@@ -5,7 +5,7 @@
   <string name="pgm_google_play_error">По якісь причині Google Maps Android API v2 не доступний на цьому пристрої.</string>
   <string name="pgm_google_play_developer_error">Програма невірно налаштована. Виникла фатальна помилка. Розробник додатку повинен подивитись в логи, щоб виправити помилку.</string>
   <string name="pgm_google_play_internal_error">Відбулася внутрішня помилка Google Play Services. Будь ласка, спробуйте ще раз для вирішення проблеми.</string>
-  <string name="pgm_google_play_invalid_account">Ви спробували підключитися до сервісу з недійсним ім'ям облікового запису.</string>
+  <string name="pgm_google_play_invalid_account">Ви спробували підключитися до сервісу з недійсним ім\'ям облікового запису.</string>
   <string name="pgm_google_play_lincense_check_failed">Виникла фатальна помилка. Додаток не ліцензійований для користувача.</string>
   <string name="pgm_google_play_network_error">Виникла помилка мережі. Будь ласка, спробуйте ще раз для вирішення проблеми.</string>
   <string name="pgm_google_play_service_disabled">Встановлений Google Play Services на цьому пристрої - відключений. Будь ласка, увімкніть Google Play Services.</string>


### PR DESCRIPTION
Without escaping this apostrophe "cordova run" build for android platform 6.3. fail.
Cordova version which fail : 7.1.0