### PR TITLE
update plugin.xml remove  invalid Japanese config

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -363,16 +363,6 @@ The native map view is faster, use less network usage, display 3D views, and eve
         <header-file src="src/ios/GoogleMaps/UIImageCache.h" />
         <source-file src="src/ios/GoogleMaps/UIImageCache.m" />
 
-        <config-file target="*-Info.plist" parent="CFBundleDevelopmentRegion">
-          <array>
-            <string>Japanese</string>
-          </array>
-        </config-file>
-        <config-file target="*-Info.plist" parent="CFBundleLocalizations">
-            <array>
-                <string>ja</string>
-            </array>
-        </config-file>
         <resource-file src="src/ios/strings/Base.lproj/pgm_Localizable.strings" target="Base.lproj/pgm_Localizable.strings" />
         <resource-file src="src/ios/strings/ja.lproj/pgm_Localizable.strings" target="ja.lproj/pgm_Localizable.strings" />
         <resource-file src="src/ios/strings/ru.lproj/pgm_Localizable.strings" target="ru.lproj/pgm_Localizable.strings" />


### PR DESCRIPTION
remove Japanese from CFBundleDevelopmentRegion and CFBundleLocalizations as this will always enforce native development language to Japanese, 

for example, all copy past select all will be in Japanese 

u can have 

        <config-file target="*-Info.plist" parent="CFBundleDevelopmentRegion">
          <array>
            <string>Japanese</string>
          </array>
        </config-file>
        <config-file target="*-Info.plist" parent="CFBundleLocalizations">
            <array>
                <string>ja</string>
            </array>
        </config-file>