### PR TITLE
Added improvements to Tile Overlay

### DIFF
--- a/src/android/plugin/google/maps/PluginTileOverlay.java
+++ b/src/android/plugin/google/maps/PluginTileOverlay.java
@@ -199,6 +199,23 @@ public class PluginTileOverlay extends MyPlugin implements MyPluginInterface {
   }
 
   /**
+   * Clears the tile cache
+   * @param args
+   * @param callbackContext
+   * @throws JSONException
+   */
+  public void invalidate(final JSONArray args, final CallbackContext callbackContext) throws JSONException {
+      String id = args.getString(0);
+      TileOverlay tileOverlay = (TileOverlay)pluginMap.objects.get(id);
+      if (tileOverlay == null) {
+          callbackContext.error("TileLayer(" + id + ") not found");
+      } else {
+          tileOverlay.clearTileCache();
+          callbackContext.success();
+      }
+  }
+
+  /**
    * Set fadeIn for the object
    * @param args
    * @param callbackContext

--- a/src/android/plugin/google/maps/PluginTileProvider.java
+++ b/src/android/plugin/google/maps/PluginTileProvider.java
@@ -176,7 +176,14 @@ public class PluginTileProvider implements TileProvider  {
 
     try {
       InputStream inputStream = null;
-      if (urlStr.startsWith("http://") || urlStr.startsWith("https://")) {
+      if (urlStr.startsWith("data:image") {
+        //-------------------------------
+        // load image from base64 string
+        //-------------------------------
+        
+        // not yet supported
+        return null;
+      } else if (urlStr.startsWith("http://") || urlStr.startsWith("https://")) {
         //-------------------------------
         // load image from the internet
         //-------------------------------

--- a/src/ios/GoogleMaps/PluginTileOverlay.h
+++ b/src/ios/GoogleMaps/PluginTileOverlay.h
@@ -19,6 +19,7 @@
 -(void)create:(CDVInvokedUrlCommand*)command;
 -(void)setVisible:(CDVInvokedUrlCommand *)command;
 -(void)remove:(CDVInvokedUrlCommand *)command;
+-(void)invalidate:(CDVInvokedUrlCommand *)command;
 -(void)setZIndex:(CDVInvokedUrlCommand *)command;
 -(void)setFadeIn:(CDVInvokedUrlCommand *)command;
 -(void)setOpacity:(CDVInvokedUrlCommand *)command;

--- a/src/ios/GoogleMaps/PluginTileOverlay.m
+++ b/src/ios/GoogleMaps/PluginTileOverlay.m
@@ -218,7 +218,19 @@
   }];
 
 }
+-(void)invalidate:(CDVInvokedUrlCommand*)command 
+{
+    [self.executeQueue addOperationWithBlock:^{
+      NSString *tileLayerKey = [command.arguments objectAtIndex:0];
+      dispatch_async(dispatch_get_main_queue(), ^{
+          GMSTileLayer *layer = (GMSTileLayer *)[self.mapCtrl.objects objectForKey:tileLayerKey];
+          [layer clearTileCache];
+      });
 
+      CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+      [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+  }];
+}
 
 /**
  * Set z-index

--- a/src/ios/GoogleMaps/PluginTileProvider.m
+++ b/src/ios/GoogleMaps/PluginTileProvider.m
@@ -116,6 +116,15 @@ NSDictionary *debugAttributes;
      }
   }
 
+  if([urlStr hasPrefix:@"data:image"]) {
+    NSData *data = [[NSData alloc] initWithBase64EncodedString: string
+                                                       options: NSDataBase64DecodingIgnoreUnknownCharacters];
+
+    UIImage *image = [UIImage imageWithData:data];
+    [receiver receiveTileWithX:x y:y zoom:zoom image:image];
+    return;
+  }
+
   NSRange range = [urlStr rangeOfString:@"http"];
   if (range.location == 0) {
       //-------------------------

--- a/www/Map.js
+++ b/www/Map.js
@@ -1012,11 +1012,20 @@ Map.prototype.addTileOverlay = function(tilelayerOptions, callback) {
   };
 
   var onNativeCallback = function(params) {
-    var url = tilelayerOptions.getTile(params.x, params.y, params.zoom);
-    if (!url || url === "(null)" || url === "undefined" || url === "null") {
-      url = "(null)";
+    function handleResult(url) {
+      if (!url || url === "(null)" || url === "undefined" || url === "null") {
+        url = "(null)";
+      }
+      cordova_exec(null, self.errorHandler, self.id + "-tileoverlay", 'onGetTileUrlFromJS', [options._id, params.key, url]);
     }
-    cordova_exec(null, self.errorHandler, self.id + "-tileoverlay", 'onGetTileUrlFromJS', [options._id, params.key, url]);
+    var result = tilelayerOptions.getTile(params.x, params.y, params.zoom);
+    // check if "thenable" (a Promise)
+    if(result && typeof result.then === 'function') {
+      result.then(handleResult);
+    } else {
+      // not a promise
+      handleResult(result);
+    }
   };
   document.addEventListener(self.id + "-" + options._id + "-tileoverlay", onNativeCallback);
 

--- a/www/TileOverlay.js
+++ b/www/TileOverlay.js
@@ -110,6 +110,18 @@ TileOverlay.prototype.getVisible = function() {
     return this.get('visible');
 };
 
+TileOverlay.prototype.invalidate = function(callback) {
+    var self = this;
+    if(self._isRemoved) {
+        return;
+    };
+    exec.call(self, function() {
+        if(typeof callback === 'function') {
+            callback.call(self);
+        }
+    }, self.errorHandler, self.getPluginName(), 'invalidate', [self.getId()]);
+};
+
 TileOverlay.prototype.remove = function(callback) {
     var self = this;
     if (self._isRemoved) {


### PR DESCRIPTION
Added the ability to return a Promise from the getTile TileOverlay
handler.
Added "invalidate" method to Tile overlay to allow invocation of the GMS
"clearTileCache" method from JS.
Added ability to return a base64 encoded image from getTile in JS.

---

My project requires the ability to dynamically generate Tiles at runtime.  These changes would allow my project to do this.

Note I'm having a tough time attempting to test these changes.  I will be able to do more once the holiday is over.  I have a demo project developed here in an attempt to test these changes: https://github.com/Kraxxis/cordova-googlemaps-base64-example.

I also left the Android implementation of base64 handling absent; I am unsure how to do this in Java land, and it looks like there is some advanced caching going on that is not present in iOS.  Any advice you have would be helpful and appreciated.