### PR TITLE
Improvements to coordinate precision

### DIFF
--- a/src/android/plugin/google/maps/PluginKmlOverlay.java
+++ b/src/android/plugin/google/maps/PluginKmlOverlay.java
@@ -258,8 +258,8 @@ public class PluginKmlOverlay extends MyPlugin implements MyPluginInterface {
             if (!"".equals(lines[i])) {
               tmpArry = lines[i].split(",");
               latLng = new Bundle();
-              latLng.putFloat("lat", Float.parseFloat(tmpArry[1]));
-              latLng.putFloat("lng", Float.parseFloat(tmpArry[0]));
+              latLng.putDouble("lat", Double.parseDouble(tmpArry[1]));
+              latLng.putDouble("lng", Double.parseDouble(tmpArry[0]));
               latLngList.add(latLng);
             }
           }

--- a/src/ios/GoogleMaps/PluginCircle.m
+++ b/src/ios/GoogleMaps/PluginCircle.m
@@ -54,8 +54,8 @@
 
     NSDictionary *json = [command.arguments objectAtIndex:1];
     NSDictionary *latLng = [json objectForKey:@"center"];
-    float latitude = [[latLng valueForKey:@"lat"] floatValue];
-    float longitude = [[latLng valueForKey:@"lng"] floatValue];
+    double latitude = [[latLng valueForKey:@"lat"] doubleValue];
+    double longitude = [[latLng valueForKey:@"lng"] doubleValue];
     CLLocationCoordinate2D position = CLLocationCoordinate2DMake(latitude, longitude);
 
     float radius = [[json valueForKey:@"radius"] floatValue];
@@ -148,8 +148,8 @@
         NSString *circleId = [command.arguments objectAtIndex:0];
         GMSCircle *circle = [self.mapCtrl.objects objectForKey:circleId];
 
-        float latitude = [[command.arguments objectAtIndex:1] floatValue];
-        float longitude = [[command.arguments objectAtIndex:2] floatValue];
+        double latitude = [[command.arguments objectAtIndex:1] doubleValue];
+        double longitude = [[command.arguments objectAtIndex:2] doubleValue];
         CLLocationCoordinate2D center = CLLocationCoordinate2DMake(latitude, longitude);
 
         [[NSOperationQueue mainQueue] addOperationWithBlock:^{

--- a/src/ios/GoogleMaps/PluginMarker.m
+++ b/src/ios/GoogleMaps/PluginMarker.m
@@ -109,8 +109,8 @@
   NSMutableDictionary *iconProperty = nil;
   NSString *animation = nil;
   NSDictionary *latLng = [json objectForKey:@"position"];
-  float latitude = [[latLng valueForKey:@"lat"] floatValue];
-  float longitude = [[latLng valueForKey:@"lng"] floatValue];
+  double latitude = [[latLng valueForKey:@"lat"] doubleValue];
+  double longitude = [[latLng valueForKey:@"lng"] doubleValue];
 
   CLLocationCoordinate2D position = CLLocationCoordinate2DMake(latitude, longitude);
 
@@ -567,8 +567,8 @@
     NSString *markerId = [command.arguments objectAtIndex:0];
     GMSMarker *marker = [self.mapCtrl.objects objectForKey:markerId];
 
-    float latitude = [[command.arguments objectAtIndex:1] floatValue];
-    float longitude = [[command.arguments objectAtIndex:2] floatValue];
+    double latitude = [[command.arguments objectAtIndex:1] doubleValue];
+    double longitude = [[command.arguments objectAtIndex:2] doubleValue];
     CLLocationCoordinate2D position = CLLocationCoordinate2DMake(latitude, longitude);
     [[NSOperationQueue mainQueue] addOperationWithBlock:^{
       [marker setPosition:position];

--- a/src/ios/GoogleMaps/PluginPolygon.m
+++ b/src/ios/GoogleMaps/PluginPolygon.m
@@ -63,7 +63,7 @@
   NSDictionary *latLng;
   for (i = 0; i < points.count; i++) {
       latLng = [points objectAtIndex:i];
-      [mutablePath addCoordinate:CLLocationCoordinate2DMake([[latLng objectForKey:@"lat"] floatValue], [[latLng objectForKey:@"lng"] floatValue])];
+      [mutablePath addCoordinate:CLLocationCoordinate2DMake([[latLng objectForKey:@"lat"] doubleValue], [[latLng objectForKey:@"lng"] doubleValue])];
   }
 
   // Create paths of the hole property if specified.
@@ -79,7 +79,7 @@
           GMSMutablePath *holePath = [GMSMutablePath path];
           for (j = 0; j < latLngArray.count; j++) {
               latLng = [latLngArray objectAtIndex:j];
-              [holePath addLatitude:[[latLng objectForKey:@"lat"] floatValue] longitude:[[latLng objectForKey:@"lng"] floatValue]];
+              [holePath addLatitude:[[latLng objectForKey:@"lat"] doubleValue] longitude:[[latLng objectForKey:@"lng"] doubleValue]];
           }
           [holePaths addObject:holePath];
       }
@@ -200,7 +200,7 @@
       GMSMutablePath *path = [GMSMutablePath path];
       for (i = 0; i < [holes count]; i++) {
         latLng = [latLngArray objectAtIndex:i];
-        [path addLatitude:[[latLng objectForKey:@"lat"] floatValue] longitude:[[latLng objectForKey:@"lng"] floatValue]];
+        [path addLatitude:[[latLng objectForKey:@"lat"] doubleValue] longitude:[[latLng objectForKey:@"lng"] doubleValue]];
       }
       [holePaths insertObject:path atIndex:index];
 
@@ -272,7 +272,7 @@
 
       // Insert a point into the specified hole
       GMSMutablePath *path = [holePaths objectAtIndex:holeIndex];
-      CLLocationCoordinate2D position = CLLocationCoordinate2DMake([[latLng objectForKey:@"lat"] floatValue], [[latLng objectForKey:@"lng"] floatValue]);
+      CLLocationCoordinate2D position = CLLocationCoordinate2DMake([[latLng objectForKey:@"lat"] doubleValue], [[latLng objectForKey:@"lng"] doubleValue]);
       [path replaceCoordinateAtIndex:pointIndex withCoordinate:position];
       [holePaths setObject:path atIndexedSubscript:holeIndex];
 
@@ -325,7 +325,7 @@
         holePositions = [holeList objectAtIndex:i];
         for (int j = 0; j < holePositions.count; j++) {
           latLng = [holePositions objectAtIndex:j];
-          [path addCoordinate:CLLocationCoordinate2DMake([[latLng objectForKey:@"lat"] floatValue], [[latLng objectForKey:@"lng"] floatValue])];
+          [path addCoordinate:CLLocationCoordinate2DMake([[latLng objectForKey:@"lat"] doubleValue], [[latLng objectForKey:@"lng"] doubleValue])];
         }
         [holePaths addObject:path];
       }
@@ -365,7 +365,7 @@
 
       // Insert a point into the specified hole
       GMSMutablePath *path = [holePaths objectAtIndex:holeIndex];
-      CLLocationCoordinate2D position = CLLocationCoordinate2DMake([[latLng objectForKey:@"lat"] floatValue], [[latLng objectForKey:@"lng"] floatValue]);
+      CLLocationCoordinate2D position = CLLocationCoordinate2DMake([[latLng objectForKey:@"lat"] doubleValue], [[latLng objectForKey:@"lng"] doubleValue]);
       [path insertCoordinate:position atIndex:pointIndex];
       [holePaths setObject:path atIndexedSubscript:holeIndex];
 
@@ -439,7 +439,7 @@
       [mutablePath removeAllCoordinates];
       for (int i = 0; i < positionList.count; i++) {
         latLng = [positionList objectAtIndex:i];
-        [mutablePath addCoordinate:CLLocationCoordinate2DMake([[latLng objectForKey:@"lat"] floatValue], [[latLng objectForKey:@"lng"] floatValue])];
+        [mutablePath addCoordinate:CLLocationCoordinate2DMake([[latLng objectForKey:@"lat"] doubleValue], [[latLng objectForKey:@"lng"] doubleValue])];
       }
 
       // update the property
@@ -475,7 +475,7 @@
 
       GMSMutablePath *mutablePath = (GMSMutablePath *)[properties objectForKey:@"mutablePath"];
 
-      CLLocationCoordinate2D position = CLLocationCoordinate2DMake([[latLng objectForKey:@"lat"] floatValue], [[latLng objectForKey:@"lng"] floatValue]);
+      CLLocationCoordinate2D position = CLLocationCoordinate2DMake([[latLng objectForKey:@"lat"] doubleValue], [[latLng objectForKey:@"lng"] doubleValue]);
       [mutablePath insertCoordinate:position atIndex:index];
 
       // update the property
@@ -510,7 +510,7 @@
 
       GMSMutablePath *mutablePath = (GMSMutablePath *)[properties objectForKey:@"mutablePath"];
 
-      CLLocationCoordinate2D position = CLLocationCoordinate2DMake([[latLng objectForKey:@"lat"] floatValue], [[latLng objectForKey:@"lng"] floatValue]);
+      CLLocationCoordinate2D position = CLLocationCoordinate2DMake([[latLng objectForKey:@"lat"] doubleValue], [[latLng objectForKey:@"lng"] doubleValue]);
       [mutablePath replaceCoordinateAtIndex:index withCoordinate:position];
 
       // update the property

--- a/src/ios/GoogleMaps/PluginPolyline.m
+++ b/src/ios/GoogleMaps/PluginPolyline.m
@@ -66,7 +66,7 @@
       latLng = [points objectAtIndex:i];
       [mutablePath
         addCoordinate:
-          CLLocationCoordinate2DMake([[latLng objectForKey:@"lat"] floatValue], [[latLng objectForKey:@"lng"] floatValue])];
+          CLLocationCoordinate2DMake([[latLng objectForKey:@"lat"] doubleValue], [[latLng objectForKey:@"lng"] doubleValue])];
   }
 
   dispatch_async(dispatch_get_main_queue(), ^{
@@ -199,7 +199,7 @@
       NSDictionary *latLng;
       for (int i = 0; i < positionList.count; i++) {
           latLng = [positionList objectAtIndex:i];
-          position = CLLocationCoordinate2DMake([[latLng objectForKey:@"lat"] floatValue], [[latLng objectForKey:@"lng"] floatValue]);
+          position = CLLocationCoordinate2DMake([[latLng objectForKey:@"lat"] doubleValue], [[latLng objectForKey:@"lng"] doubleValue]);
       }
 
       // update the property
@@ -234,7 +234,7 @@
 
       GMSMutablePath *mutablePath = (GMSMutablePath *)[properties objectForKey:@"mutablePath"];
 
-      CLLocationCoordinate2D position = CLLocationCoordinate2DMake([[latLng objectForKey:@"lat"] floatValue], [[latLng objectForKey:@"lng"] floatValue]);
+      CLLocationCoordinate2D position = CLLocationCoordinate2DMake([[latLng objectForKey:@"lat"] doubleValue], [[latLng objectForKey:@"lng"] doubleValue]);
       [mutablePath insertCoordinate:position atIndex:index];
 
       // update the property
@@ -269,7 +269,7 @@
 
       GMSMutablePath *mutablePath = (GMSMutablePath *)[properties objectForKey:@"mutablePath"];
 
-      CLLocationCoordinate2D position = CLLocationCoordinate2DMake([[latLng objectForKey:@"lat"] floatValue], [[latLng objectForKey:@"lng"] floatValue]);
+      CLLocationCoordinate2D position = CLLocationCoordinate2DMake([[latLng objectForKey:@"lat"] doubleValue], [[latLng objectForKey:@"lng"] doubleValue]);
       [mutablePath replaceCoordinateAtIndex:index withCoordinate:position];
 
       // update the property


### PR DESCRIPTION
Coordinate precision was being lost in iOS (all cases) and Android (kml overlay) when more than 6 decimal places were required due to using floats instead of doubles. Due to this, rendered coordinates could be potentially out by a meter.