### PR TITLE
Allow remove action before map is ready

### DIFF
--- a/www/commandQueueExecutor.js
+++ b/www/commandQueueExecutor.js
@@ -33,9 +33,9 @@ function execCmd(success, error, pluginName, methodName, args, execOptions) {
   }
 
   // If the overlay is not ready in native side,
-  // do not execute any methods on it.
-  // This code works for map class especially.
-  if (!this._isReady) {
+  // do not execute any methods except remove on it.
+  // This code works for map class especially.  
+  if (!this._isReady && methodName !== "remove") {
     console.error("[ignore]" + pluginName + "." + methodName + ", because it's not ready.");
     return true;
   }


### PR DESCRIPTION
Tested on iOS and Android. I was seeing issues with the map sticking in the background when we transitioned between views. This allows us to remove the map before it is ready.