### PR TITLE
[iOS] Fixed bug in "getMyLocation" with last location result

### DIFF
--- a/src/ios/GoogleMaps/PluginLocationService.m
+++ b/src/ios/GoogleMaps/PluginLocationService.m
@@ -93,9 +93,7 @@
         //http://stackoverflow.com/questions/24268070/ignore-ios8-code-in-xcode-5-compilation
         [self.locationManager requestWhenInUseAuthorization];
 
-        NSTimeInterval timeStamp = [[NSDate date] timeIntervalSince1970];
-
-        if (self.lastLocation && timeStamp - self.lastLocation.timestamp.timeIntervalSince1970 < 2000) {
+        if (self.lastLocation && -[self.lastLocation.timestamp timeIntervalSinceNow] < 2) {
           //---------------------------------------------------------------------
           // If the user requests the location in two seconds from the last time,
           // return the last result in order to save battery usage.


### PR DESCRIPTION
Fixed bug with wrong coordinates of the current location on iOS.

Old behavior:

<img width="867" alt="screen shot 2018-07-09 at 5 57 53 pm" src="https://user-images.githubusercontent.com/13087191/42461119-6d5abb5c-83a8-11e8-8ad1-a86b3760accc.png">