### PR TITLE
Update PluginMarker.java

### DIFF
--- a/src/android/plugin/google/maps/PluginMarker.java
+++ b/src/android/plugin/google/maps/PluginMarker.java
@@ -1023,7 +1023,7 @@ public class PluginMarker extends MyPlugin implements MyPluginInterface  {
     options.noCaching = noCaching;
     final int taskId = options.hashCode();
 
-    AsyncLoadImageInterface onComplete = new AsyncLoadImageInterface() {
+    final AsyncLoadImageInterface onComplete = new AsyncLoadImageInterface() {
       @Override
       public void onPostExecute(AsyncLoadImage.AsyncLoadImageResult result) {
         iconLoadingTasks.remove(taskId);


### PR DESCRIPTION
Fix for a compilation error:
.../platforms/android/src/plugin/google/maps/PluginMarker.java:1149: error: local variable onComplete is accessed from within inner class; needs to be declared final
        AsyncLoadImage task = new AsyncLoadImage(cordova, webView, options, onComplete);
                                                                            ^
