### PR TITLE
Update Cluster.js

### DIFF
--- a/www/Cluster.js
+++ b/www/Cluster.js
@@ -112,7 +112,14 @@ Cluster.prototype.remove = function() {
   });
 };
 Cluster.prototype.getItemLength = function() {
-  return this._markerOptsArray.length;
+  //return this._markerOptsArray.length;
+   var inc = 0;
+      this._markerOptsArray.forEach(function(markerOpts) {
+        if(markerOpts.visible === true){
+          ++inc;
+        }
+      });
+  return inc;
 };
 
 module.exports = Cluster;


### PR DESCRIPTION
Failing to have a method "getItemVisibleLength()", it would be good in the logic of not raised in the count of the markerCluster the sum of markers visible or not visible.

What do you think ?