### PR TITLE
Fix bottom area clickable #2409

### DIFF
--- a/src/ios/GoogleMaps/MyPluginLayer.m
+++ b/src/ios/GoogleMaps/MyPluginLayer.m
@@ -330,6 +330,8 @@
   // e.g. PhoneGap-Plugin-ListPicker, etc
   UIView *subview;
   NSArray *subviews = [self.webView.superview subviews];
+  CGRect statusBarFrame = [UIApplication sharedApplication].statusBarFrame;
+  CGPoint subviewPoint = CGPointMake(browserClickPoint.x, browserClickPoint.y - statusBarFrame.size.height);
   for (int i = ((int)[subviews count] - 1); i >= 0; i--) {
     subview = [subviews objectAtIndex: i];
     //NSLog(@"--->subview[%d] = %@", i, subview);
@@ -342,8 +344,6 @@
       continue;
     }
 
-    CGRect statusBarFrame = [UIApplication sharedApplication].statusBarFrame;
-    CGPoint subviewPoint = CGPointMake(browserClickPoint.x, browserClickPoint.y - statusBarFrame.size.height);
     UIView *hit = [subview hitTest:subviewPoint withEvent:event];
 
     if (hit) {

--- a/src/ios/GoogleMaps/MyPluginLayer.m
+++ b/src/ios/GoogleMaps/MyPluginLayer.m
@@ -342,7 +342,9 @@
       continue;
     }
 
-    UIView *hit = [subview hitTest:point withEvent:event];
+    CGRect statusBarFrame = [UIApplication sharedApplication].statusBarFrame;
+    CGPoint subviewPoint = CGPointMake(browserClickPoint.x, browserClickPoint.y - statusBarFrame.size.height);
+    UIView *hit = [subview hitTest:subviewPoint withEvent:event];
 
     if (hit) {
       if (subview == self.webView) {


### PR DESCRIPTION
This fixes the problem when using `corodova-plugin-googlemaps` together with `cordova-plugin-statusbar` to make the bottom 20px clickable (#2409).
When running the hitTest on the subviews the height of the statusbar has to be accounted for. I tested my changes with and without the `cordova-plugin-statusbar` beeing installed, both ways worked fine.