### PR TITLE
plugin.xml: Use github: prefix for dependency

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -476,7 +476,7 @@
       </array>
     </config-file>
 
-    <dependency id="com.googlemaps.ios" url="https://github.com/mapsplugin/cordova-plugin-googlemaps-sdk.git#2.7.0"/>
+    <dependency id="com.googlemaps.ios" url="github:mapsplugin/cordova-plugin-googlemaps-sdk#2.7.0"/>
 
     <hook type="before_platform_add" src="src/ios/check_sdk_version.js"/>
     <hook type="before_plugin_install" src="src/ios/check_sdk_version.js"/>


### PR DESCRIPTION
`https://...` links are for tarballs, according to the spec.  While `npm` does detect it is a git link, other package managers do not, such as https://github.com/pnpm/pnpm/issues/1376 .

Either `git+` or `github:` are required for git links.  Most people now use a package manager version which supports `github:`