### PR TITLE
Feature test for viewport-fit=cover

### DIFF
--- a/www/pluginInit.js
+++ b/www/pluginInit.js
@@ -63,15 +63,22 @@ function pluginInit() {
 
   var viewportTagContent = 'width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no';
 
-  // Detect if iOS device
-  if (/(iPhone|iPod|iPad)/i.test(window.navigator.userAgent)) {
-    // Get iOS major version
-    var iosVersion = parseInt((window.navigator.userAgent).match(/OS (\d+)_(\d+)_?(\d+)? like Mac OS X/i)[1]);
-    // Detect if device is running >iOS 11
-    // iOS 11's UIWebView and WKWebView changes the viewport behaviour to render viewport without the status bar. Need to override with "viewport-fit: cover" to include the status bar.
-    if (iosVersion >= 11) {
-      viewportTagContent += ', viewport-fit=cover';
-    }
+  //
+  // Detect support for CSS env() variable
+  //
+  var envTestDiv = '<div id="envTest" style="margin-top:-99px;margin-top:env(safe-area-inset-top);position:absolute;z-index:-1;"></div>';
+
+  document.body.insertAdjacentHTML('afterbegin', envTestDiv);
+
+  var testElement = document.getElementById('envTest');
+  var computedStyles = window.getComputedStyle(testElement);
+  var testResult = computedStyles.getPropertyValue('margin-top');
+
+  document.body.removeChild(testElement);
+
+  // if browser supports env(), returns a pixel value as string, even if 0px
+  if (testResult != '-99px') {
+    viewportTagContent += ', viewport-fit=cover';
   }
 
   // Update viewport tag attribute


### PR DESCRIPTION
Current functionality checks user agent for iOS 11 or higher. If `true`, adds `viewport-fit=cover` to the `viewport` meta tag. This allows use of safe areas, for example, the "notch" at the top of iPhone X.

Google now [supports this feature](https://blog.chromium.org/2018/08/chrome-69-beta-av1-video-decoder-css.html) in Chrome 69, opening the door for Android phones to use Display Cutouts.

I propose this plugin should test the browser for support of the CSS variable `env()` which delivers the pixel value of safe spaces, like this:

#box {
  margin-top: env(safe-area-inset-top);
  margin-left: env(safe-area-inset-left);
  margin-bottom: env(safe-area-inset-bottom);
  margin-right: env(safe-area-inset-right);
}

The included test creates a div with a `margin-top` set to `-99px` followed by `margin-top:env(safe-area-inset-top)`.

If the browser does not support `env()`, then `margin-top:env(safe-area-inset-top)` is ignored and the calculated value remains `-99px`. In this case, `viewport-fit=cover` is not added to the `viewport` meta tag.

If the browser does support `env()`, the calculated value will be something other than `-99px`, either `0px` or a specific value associated with that phone. In this case, `viewport-fit=cover` is added to the `viewport` meta tag, allowing use of `env()` for display cutouts.