### PR TITLE
Add a custom resolver so that we can require our own project files

### DIFF
--- a/jest-cordova-resolver.js
+++ b/jest-cordova-resolver.js
@@ -1,0 +1,22 @@
+var Resolver = require('jest-resolve');
+var path = require('path');
+var fs = require('fs');
+
+var pluginModuleRegex = /^cordova-plugin-googlemaps\.(.*)/;
+var pathBrowser = './src/browser';
+var pathWww = './www';
+
+module.exports = function(moduleId, options) {
+  if (pluginModuleRegex.test(moduleId)) {
+    var fileName = moduleId.match(pluginModuleRegex)[1] + '.js';
+    if (fs.existsSync(path.resolve(pathBrowser, fileName))) {
+      return path.resolve(pathBrowser, fileName);
+    }
+    if (fs.existsSync(path.resolve(pathWww, fileName))) {
+      return path.resolve(pathWww, fileName);
+    }
+
+    throw new Error(moduleId + 'could not be located');
+  }
+  return Resolver.findNodeModule(moduleId, options);
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,7 @@ module.exports = {
   moduleNameMapper: {
     '^cordova/(.*)$': '<rootDir>/node_modules/cordova-js/src/common/$1',
   },
+  resolver: './jest-cordova-resolver.js',
   globals: {
     cordova: {},
   },

--- a/src/browser/__test__/PluginMap.spec.js
+++ b/src/browser/__test__/PluginMap.spec.js
@@ -1,0 +1,19 @@
+const PluginMap = require('../PluginMap');
+
+describe('PluginMap', () => {
+  it('should exist', () => {
+    expect(PluginMap).toBeDefined();
+  });
+
+  describe('toDataURL', () => {
+    afterEach(() => {
+      document.body.innerHTML = '';
+    });
+
+    it('should exist', () => {
+      var mapId = 'map';
+      document.body.innerHTML = '<div __pluginMapId="' + mapId + '"></div>';
+      expect(new PluginMap(mapId, {}).toDataURL).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
The following PR makes it to where files that `require` files under the plugin namespace can be resolved. 

```
var event = require('cordova-plugin-googlemaps.event'),
  BaseClass = require('cordova-plugin-googlemaps.BaseClass'),
  LatLng = require('cordova-plugin-googlemaps.LatLng'),
  MapTypeId = require('cordova-plugin-googlemaps.MapTypeId');
```

Will now be correctly resolved to the correct location. Since Cordova implements it's own `require` function we need to customize jests when importing something from our own plugin.