### PR TITLE
Implement demo of using JSDoc to support type checking js

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     }
   ],
   "scripts": {
-    "test": "jest && npm run eslint",
+    "check-types": "tsc",
+    "test": "npm run check-types && npm run jest && npm run eslint",
     "jest": "jest",
     "test:watch": "jest --watch",
     "eslint": "node node_modules/eslint/bin/eslint www src"
@@ -55,8 +56,10 @@
   },
   "homepage": "https://github.com/mapsplugin/cordova-plugin-googlemaps",
   "devDependencies": {
+    "@types/googlemaps": "^3.30.16",
     "cordova-js": "^4.2.4",
     "eslint": "^5.7.0",
-    "jest": "^23.6.0"
+    "jest": "^23.6.0",
+    "typescript": "^3.1.6"
   }
 }

--- a/src/browser/PluginGeocoder.js
+++ b/src/browser/PluginGeocoder.js
@@ -1,5 +1,6 @@
 
 
+// @ts-ignore
 var BaseArrayClass = require('cordova-plugin-googlemaps.BaseArrayClass');
 
 var geocoder = null;
@@ -146,6 +147,12 @@ QUEUE.on('next', function() {
 });
 
 module.exports = {
+  /**
+   *
+   * @param {(result: GeocoderResult[]) => void} onSuccess
+   * @param {(err: string) => void} onError
+   * @param {[GeocoderRequest]} args
+   */
   'geocode': function(onSuccess, onError, args) {
     var request = args[0];
     var geocoderRequest = {};
@@ -176,4 +183,5 @@ module.exports = {
 };
 
 
+// @ts-ignore
 require('cordova/exec/proxy').add('PluginGeocoder', module.exports);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "commonjs",
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "esModuleInterop": true
+  },
+  "include": [
+    "src/browser/PluginGeocoder.js",
+    "typings/**/*.d.ts"
+  ],
+}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,0 +1,69 @@
+interface ILatLng {
+  lat: number;
+  lng: number;
+}
+
+interface ILatLngBounds {
+  northeast: ILatLng;
+  southwest: ILatLng;
+}
+
+interface GeocoderRequest {
+  /**
+   * The address property or position property is required.
+   * You can not specify both property at the same time.
+   *
+   * [geocoding usage1]
+   * let request: GeocoderRequest = {
+   *   address: "Los Angeles, California, USA"
+   * }
+   *
+   * [geocoding usage2]
+   * let request: GeocoderRequest = {
+   *   address: [
+   *    "Los Angeles, California, USA",
+   *    "San Francisco, California, USA",
+   *   ]
+   * }
+   */
+  address?: string | string[];
+  /**
+   *
+   * [reverse-geocoding usage1]
+   * let request: GeocoderRequest = {
+   *   position: {"lat": 37.421655, "lng": -122.085637}
+   * }
+   *
+   * [reverse-geocoding usage2]
+   * let request: GeocoderRequest = {
+   *   position: [
+   *    {"lat": 37.421655, "lng": -122.085637},
+   *    {"lat": 37.332, "lng": -122.030781}
+   *   ]
+   * }
+   */
+  position?: ILatLng | ILatLng[];
+
+  bounds?: ILatLng | ILatLng[];
+}
+
+interface GeocoderResult {
+  adminArea?: string;
+  country?: string;
+  countryCode?: string;
+  extra?: {
+    featureName?: string;
+    lines?: string[];
+    permises?: string;
+    phone?: string;
+    url?: string;
+  };
+  locale?: string;
+  locality?: string;
+  position?: ILatLng;
+  postalCode?: string;
+  subAdminArea?: string;
+  subLocality?: string;
+  subThoroughfare?: string;
+  thoroughfare?: string;
+}


### PR DESCRIPTION
@wf9a5m75 I am curious to get your thoughts on adding the type checking to the project without having to convert the entire project to typescript. Would this be something that you are in favor of?

Currently there are types in the `ionic-native` repo. It seems like it would be beneficial to be able to reference them in this project as well to help keep the types in sync as well as providing type checking to this project which will help reduce chance of errors.

This PR is to demo how it could be achieved. We could export the types from this project using the `package.json` `types | typings` field and then the `ionic-native` plugin could list this as a `devDependency`. Another option would be to put the types in their own repo in which both this repo and the ionic-native one would depend on but I am leaning towards moving them into this project in order to reduce complexity.

It would be an effort I can help with over time but as we move types over we can list files in the `includes` field of `tsconfig` and that will provide type checking moving forward.