### PR TITLE
Fix invalid JSON for locale "da", fix typo for locale "de"

### DIFF
--- a/src/ios/strings/pgm_Localizable_da.json
+++ b/src/ios/strings/pgm_Localizable_da.json
@@ -1,23 +1,12 @@
-/*
- * Generic
- */
-"CLOSE_BUTTON" = "ZAMKNIJ";
-
-/*
- * CordovaGoogleMaps.m
- */
-"APIKEY_IS_UNDEFINED_TITLE" = "Błąd klucza API";
-"APIKEY_IS_UNDEFINED_MESSAGE" = "Zmienna \"API_KEY_FOR_IOS\" nie została zarejestrowana.";
-
-"APP_NAME_ERROR_TITLE" = "Proszę zmienić plik config.xml";
-"APP_NAME_ERROR_MESSAGE" = "Google Maps SDK dla iOS powoduje błędy, jeżeli CFBundleExecutable zawiera nie angielskie znaki.\nWięcej szczegółów dostępnych w komentarzu w pliku CordovaGoogleMaps.m.";
-
-/*
- * PluginLocationService.m
- */
-"LOCATION_IS_UNAVAILABLE_ERROR_TITLE" = "Usługi lokalizacji są niedostępne";
-"LOCATION_IS_UNAVAILABLE_ERROR_MESSAGE" = "Aplikacja wymaga dostępu do usług lokalizacji. Proszę włączyć  \"Ustawienia > Prywatność > Usługi lokalizacji\"";
-
-"LOCATION_IS_DENIED_MESSAGE" = "Aplikacja nie posiada zezwolenia na używanie usług lokalizacji.";
-"CAN_NOT_GET_LOCATION_MESSAGE" = "Nie można określić położenia.";
-"LOCATION_REJECTED_BY_USER_MESSAGE" = "Usługi lokalizacji zostały odrzucone przez użytkownika.";
+{
+  "CLOSE_BUTTON" : "ZAMKNIJ",
+  "APIKEY_IS_UNDEFINED_TITLE" : "Błąd klucza API",
+  "APIKEY_IS_UNDEFINED_MESSAGE" : "Zmienna \"API_KEY_FOR_IOS\" nie została zarejestrowana.",
+  "APP_NAME_ERROR_TITLE" : "Proszę zmienić plik config.xml",
+  "APP_NAME_ERROR_MESSAGE" : "Google Maps SDK dla iOS powoduje błędy, jeżeli CFBundleExecutable zawiera nie angielskie znaki.\nWięcej szczegółów dostępnych w komentarzu w pliku CordovaGoogleMaps.m.",
+  "LOCATION_IS_UNAVAILABLE_ERROR_TITLE" : "Usługi lokalizacji są niedostępne",
+  "LOCATION_IS_UNAVAILABLE_ERROR_MESSAGE" : "Aplikacja wymaga dostępu do usług lokalizacji. Proszę włączyć  \"Ustawienia > Prywatność > Usługi lokalizacji\"",
+  "LOCATION_IS_DENIED_MESSAGE" : "Aplikacja nie posiada zezwolenia na używanie usług lokalizacji.",
+  "CAN_NOT_GET_LOCATION_MESSAGE" : "Nie można określić położenia.",
+  "LOCATION_REJECTED_BY_USER_MESSAGE" : "Usługi lokalizacji zostały odrzucone przez użytkownika."
+}

--- a/src/ios/strings/pgm_Localizable_de.json
+++ b/src/ios/strings/pgm_Localizable_de.json
@@ -3,7 +3,7 @@
   "APIKEY_IS_UNDEFINED_TITLE" : "API Key Fehler",
   "APIKEY_IS_UNDEFINED_MESSAGE" : "Die Variable \"API_KEY_FOR_IOS\" ist nicht definiert.",
   "APP_NAME_ERROR_TITLE" : "Du musst die config.xml Datei ändern.",
-  "APP_NAME_ERROR_MESSAGE" : "Die Google Maps SDK für iOS stürzt ab,, wenn CFBundleExecutable non-Latin Zeichen enthält.\nFür weitere Informationen bitte die CordovaGoogleMaps.m Datei anschauen.",
+  "APP_NAME_ERROR_MESSAGE" : "Die Google Maps SDK für iOS stürzt ab, wenn CFBundleExecutable non-Latin Zeichen enthält.\nFür weitere Informationen bitte die CordovaGoogleMaps.m Datei anschauen.",
   "LOCATION_IS_UNAVAILABLE_ERROR_TITLE" : "Lokalisierung ist nicht verfügbar.",
   "LOCATION_IS_UNAVAILABLE_ERROR_MESSAGE" : "Diese App benötigt Zugriff auf deinen Standort. Bitte aktiviere diese unter \"Einstellungen > Datenschutz > Lokalisierung\"",
   "LOCATION_IS_DENIED_MESSAGE" : "Dieser App wurde der Zugriff auf die Lokalisierung verweigert.",


### PR DESCRIPTION
I just stumbled across two issue regarding localisation on iOS. 

The main issue looks like an unfinished refactoring when switching to JSON locales files.