### PR TITLE
#2544 map.addKmlOverlay throw "self.map.addMarker(...).then is not a function" 

### DIFF
--- a/www/KmlLoader.js
+++ b/www/KmlLoader.js
@@ -614,7 +614,7 @@ KmlLoader.prototype.parsePointTag = function(params, callback) {
     try {      
       self.map.addMarker(markerOptions, function(_marker){
         resolve(_marker);
-      })
+      });
     }
     catch (error) {
       reject(error);

--- a/www/KmlLoader.js
+++ b/www/KmlLoader.js
@@ -611,7 +611,14 @@ KmlLoader.prototype.parsePointTag = function(params, callback) {
     //
     //   image.src = markerOptions.icon.url;
     // } else {
-    self.map.addMarker(markerOptions).then(resolve).catch(reject);
+    try {      
+      self.map.addMarker(markerOptions, function(_marker){
+        resolve(_marker);
+      })
+    }
+    catch (error) {
+      reject(error);
+    }
     //    }
   })).then(callback);
 


### PR DESCRIPTION
 In KmlLoader.js, line 614, is expected to addMarker returns Promise but the Map.addMarker() returns an object of type Marker, not a Promise. (issue #2544)