### PR TITLE
Fix toDataURL for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Cordova GoogleMaps plugin for Android, iOS and Browser v2.5.2
+# Cordova GoogleMaps plugin for Android, iOS and Browser v2.5.3-beta
 
 | Download | Build test (master branch)|
 |----------|---------------------------|

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Cordova GoogleMaps plugin for Android, iOS and Browser v2.5.1-beta
+# Cordova GoogleMaps plugin for Android, iOS and Browser v2.5.1
 
-| Download | Build test (master branch)|
+| Download | Build test |
 |----------|---------------------------|
-| [![](https://img.shields.io/npm/dm/cordova-plugin-googlemaps.svg)](https://npm-stat.com/charts.html?package=cordova-plugin-googlemaps) |[![](https://travis-ci.org/mapsplugin/cordova-plugin-googlemaps.svg?branch=multiple_maps)](https://travis-ci.org/mapsplugin/cordova-plugin-googlemaps/branches) |
+| [![](https://img.shields.io/npm/dm/cordova-plugin-googlemaps.svg)](https://npm-stat.com/charts.html?package=cordova-plugin-googlemaps) |[![](https://travis-ci.org/mapsplugin/cordova-plugin-googlemaps.svg?branch=master)](https://travis-ci.org/mapsplugin/cordova-plugin-googlemaps/branches) |
 
   This plugin displays Google Maps in your application.
   This plugin uses these libraries for each platforms:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-googlemaps",
-  "version": "2.5.1-beta-20190217-2219",
+  "version": "2.5.1",
   "description": "Google Maps native SDK for Android and iOS, and Google Maps JavaScript API v3 for browser.",
   "cordova": {
     "id": "cordova-plugin-googlemaps",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="cordova-plugin-googlemaps" version="2.5.1-beta-20190217-2219" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="cordova-plugin-googlemaps" version="2.5.1" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
   <name>cordova-plugin-googlemaps</name>
   <js-module name="Promise" src="www/Promise.js" />
   <asset src="www/promise-7.0.4.min.js.map" target="promise-7.0.4.min.js.map" />

--- a/src/ios/GoogleMaps/PluginMap.m
+++ b/src/ios/GoogleMaps/PluginMap.m
@@ -693,8 +693,9 @@
     [self.mapCtrl.executeQueue addOperationWithBlock:^{
       NSData *imageData = UIImagePNGRepresentation(image);
       NSString* base64Encoded = [imageData base64EncodedStringWithOptions:0];
+      NSString* base64EncodedWithData = [@"data:image/png;base64," stringByAppendingString:base64Encoded];
 
-      CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:base64Encoded];
+      CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:base64EncodedWithData];
       [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
     }];
   }];


### PR DESCRIPTION
The method toDataURL returns a base64 encoded string without prepending the `data:image/png;base64,` part. This PR prepends the data part.
