### PR TITLE
Fix missing data part in toDataURL

### DIFF
--- a/src/ios/GoogleMaps/PluginMap.m
+++ b/src/ios/GoogleMaps/PluginMap.m
@@ -693,8 +693,9 @@
     [self.mapCtrl.executeQueue addOperationWithBlock:^{
       NSData *imageData = UIImagePNGRepresentation(image);
       NSString* base64Encoded = [imageData base64EncodedStringWithOptions:0];
-
-      CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:base64Encoded];
+      NSString* base64EncodedWithData = [@"data:image/png;base64," stringByAppendingString:base64Encoded];
+        
+      CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:base64EncodedWithData];
       [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
     }];
   }];


### PR DESCRIPTION
The method toDataURL returns a base64 encoded string without prepending the `data:image/png;base64,` part.

This commit prepends the `data:image/png;base64,` part in the toDataURL method on iOS.

Fixes: #2572
