### PR TITLE
updated requireCordovaModule to require for non-cordova modules (Supp…

### DIFF
--- a/src/ios/check_sdk_version.js
+++ b/src/ios/check_sdk_version.js
@@ -2,8 +2,8 @@ module.exports = function (ctx) {
 
   var PluginInfoProvider = ctx.requireCordovaModule('cordova-common').PluginInfoProvider;
 
-  var Q = ctx.requireCordovaModule('q'),
-    path = ctx.requireCordovaModule('path');
+  var Q = require('q'),
+    path = require('path');
 
   var projectRoot = ctx.opts.projectRoot;
   return Q.Promise(function (resolve, reject) {


### PR DESCRIPTION
Changed `requireCordovaModule` to `require` for non-cordova-modules 

referencing this issue #2581 

I tested the changes with `cordova 9.0.0` and everything worked as expected.
