### PR TITLE
Prevent animation reset on refresh layout

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -124,7 +124,7 @@
 
   <engines>
     <engine name="cordova" version=">=7.0.0" />
-    <engine name="cordova-ios" version=">=5.0.0" />
+    <engine name="cordova-ios" version=">=4.5.0" />
     <engine name="apple-xcode" version=">=9.0.0" />
     <engine name="apple-ios" version=">=10.0.0" />
   </engines>

--- a/www/Map.js
+++ b/www/Map.js
@@ -77,7 +77,7 @@ utils.extend(Map, Overlay);
 Map.prototype.refreshLayout = function() {
   // Webkit redraw mandatory
   // http://stackoverflow.com/a/3485654/697856
-  document.body.style.display = 'none';
+  document.body.style.display = 'inline-block';
   document.body.offsetHeight;
   document.body.style.display = '';
 


### PR DESCRIPTION
We set up a transition page with custom animation while loading the map.  We found that when using a transition page to hide the map being loaded, the current code (using display: none) resets the animations.  Using 'display: inline-block' has the same functionality but doesn't create a blip or reset.  

I also found another solution... the following code does the exact same thing but is much less invasive and may have a lot less side effects since it doesn't effect the display of the body. This will trigger a hardware reset and then remove it for if they re-enter the map:
```
  document.body.style.transform = 'rotateZ(0deg)';
  document.body.style.transform = '';
```

Both methods have been tested and confirmed to work on iOS.

A similar method to the above is also noted on the stack overflow post you reference within the code block.

I am happy to create another pull request with the transform code block if desired.