### PR TITLE
Added Windows platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 <img src="https://raw.githubusercontent.com/mapsplugin/cordova-plugin-googlemaps-doc/master/v2.3.0/hello-world/image1.gif"  height="300">
 </td>
 <td>
-<h3>Browser</h3>
+<h3>Browser, Windows</h3>
 <img src="https://raw.githubusercontent.com/mapsplugin/cordova-plugin-googlemaps/master/images/browser_demo.gif" height="300">
 </td>
 </tr>
@@ -105,6 +105,25 @@
   $> cordova run (browser/android/ios) -- --live-reload
   ```
 
+## Windows platform
+
+  We support windows platform now!
+  You can develop your application with windows, then run it!
+  At the end of development, you can upload the html files to your server, or run it on Android, iOS or Windows devices.
+
+  ```
+  $> cordova run windows
+  ```
+
+  If you want to use `live-reload`, but you don't want to use other framework or without framework,
+  [cordova-plugin-browsersync](https://www.npmjs.com/package/cordova-plugin-browsersync) is useful.
+
+  ```
+  $> cordova plugin add cordova-plugin-browsersync
+
+  $> cordova run (browser/android/ios/windows) -- --live-reload
+  ```
+
 
 ### API key (Android and iOS platforms)
 
@@ -120,14 +139,14 @@
   </widget>
   ```
 
-### API key (Browser platform)
+### API key (Browser and Windows platforms)
 
-  In the browser platform, the maps plugin uses [Google Maps JavaScript API v3](https://developers.google.com/maps/documentation/javascript/)
+  In the browser and windows platforms, the maps plugin uses [Google Maps JavaScript API v3](https://developers.google.com/maps/documentation/javascript/)
 
   You need to set **two API keys for Google Maps JavaScript API v3**.
 
   ```js
-  // If your app runs this program on browser,
+  // If your app runs this program on browser or windows,
   // you need to set `API_KEY_FOR_BROWSER_RELEASE` and `API_KEY_FOR_BROWSER_DEBUG`
   // before `plugin.google.maps.Map.getMap()`
   //

--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
   "name": "cordova-plugin-googlemaps",
   "version": "2.6.2",
-  "description": "Google Maps native SDK for Android and iOS, and Google Maps JavaScript API v3 for browser.",
+  "description": "Google Maps native SDK for Android and iOS, and Google Maps JavaScript API v3 for browser/windows.",
   "cordova": {
     "id": "cordova-plugin-googlemaps",
     "platforms": [
       "android",
       "ios",
-      "browser"
+      "browser",
+      "windows"
     ]
   },
   "repository": {
@@ -22,7 +23,8 @@
     "ecosystem:cordova",
     "cordova-android",
     "cordova-ios",
-    "cordova-browser"
+    "cordova-browser",
+    "cordova-windows"
   ],
   "engines": [
     {

--- a/plugin.xml
+++ b/plugin.xml
@@ -542,4 +542,60 @@
     </js-module>
   </platform>
 
+  <!-- windows -->
+  <platform name="windows">
+    <info>
+      Official document https://github.com/mapsplugin/cordova-plugin-googlemaps-doc/blob/master/v2.3.0/README.md Please consider to buy a beer for us 🍺 https://github.com/mapsplugin/cordova-plugin-googlemaps#buy-us-a-beer
+    </info>
+
+    <js-module name="googlemaps-cdv-plugin" src="www/plugin-loader-for-browser.js">
+      <clobbers target="plugin.google.maps"/>
+    </js-module>
+    <js-module name="js_CordovaGoogleMaps" src="www/js_CordovaGoogleMaps-for-browser.js">
+      <runs/>
+    </js-module>
+    <js-module name="CordovaGoogleMaps" src="src/browser/CordovaGoogleMaps.js">
+      <runs/>
+    </js-module>
+    <js-module name="PluginMap" src="src/browser/PluginMap.js">
+      <runs/>
+    </js-module>
+    <js-module name="PluginMarker" src="src/browser/PluginMarker.js">
+      <runs/>
+    </js-module>
+    <js-module name="PluginCircle" src="src/browser/PluginCircle.js">
+      <runs/>
+    </js-module>
+    <js-module name="PluginGroundOverlay" src="src/browser/PluginGroundOverlay.js">
+      <runs/>
+    </js-module>
+    <js-module name="PluginKmlOverlay" src="src/browser/PluginKmlOverlay.js">
+      <runs/>
+    </js-module>
+    <js-module name="PluginMarkerCluster" src="src/browser/PluginMarkerCluster.js">
+      <runs/>
+    </js-module>
+    <js-module name="PluginPolygon" src="src/browser/PluginPolygon.js">
+      <runs/>
+    </js-module>
+    <js-module name="PluginPolyline" src="src/browser/PluginPolyline.js">
+      <runs/>
+    </js-module>
+    <js-module name="PluginStreetViewPanorama" src="src/browser/PluginStreetViewPanorama.js">
+      <runs/>
+    </js-module>
+    <js-module name="PluginTileOverlay" src="src/browser/PluginTileOverlay.js">
+      <runs/>
+    </js-module>
+    <js-module name="PluginLocationService" src="src/browser/PluginLocationService.js">
+      <runs/>
+    </js-module>
+    <js-module name="PluginGeocoder" src="src/browser/PluginGeocoder.js">
+      <runs/>
+    </js-module>
+    <js-module name="PluginEnvironment" src="src/browser/PluginEnvironment.js">
+      <runs/>
+    </js-module>
+  </platform>
+
 </plugin>

--- a/src/browser/CordovaGoogleMaps.js
+++ b/src/browser/CordovaGoogleMaps.js
@@ -16,6 +16,8 @@ document.addEventListener('load_googlemaps', function() {
   if (envOptions) {
     if (location.protocol === 'https:') {
       API_KEY_FOR_BROWSER = envOptions.API_KEY_FOR_BROWSER_RELEASE;
+    } else if (location.protocol === 'ms-appx-web:'){
+      API_KEY_FOR_BROWSER = envOptions.API_KEY_FOR_BROWSER_RELEASE;
     } else {
       API_KEY_FOR_BROWSER = envOptions.API_KEY_FOR_BROWSER_DEBUG;
     }


### PR DESCRIPTION
I've added support for the windows platform based on the browser platform.
It uses the Javascript V3 API.  For the most part, it was packaging.  There was one code addition need to check for "ms-appx-web:" as a protocol

My app depends heavily on mapping and seems to work just fine with this.  As background, I had originally implemented using the  V3 API across all the platforms, but was getting killed by the costs from google.  Then I found this awesome plugin and was able to use the native SDKs for Android and iOS (the bulk of my customer base).