### PR TITLE
Add Heatmap support in Android to plugin

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -40,6 +40,9 @@
   <js-module name="Circle" src="www/Circle.js">
     <runs/>
   </js-module>
+  <js-module name="Heatmap" src="www/Heatmap.js">
+    <runs/>
+  </js-module>
   <js-module name="TileOverlay" src="www/TileOverlay.js">
     <runs/>
   </js-module>
@@ -124,7 +127,7 @@
 
   <engines>
     <engine name="cordova" version=">=7.0.0" />
-    <engine name="cordova-ios" version=">=4.5.0" />
+    <engine name="cordova-ios" version=">=5.0.0" />
     <engine name="apple-xcode" version=">=9.0.0" />
     <engine name="apple-ios" version=">=10.0.0" />
   </engines>
@@ -172,6 +175,9 @@
       <feature name="PluginCircle">
         <param name="android-package" value="plugin.google.maps.PluginCircle"/>
       </feature>
+      <feature name="PluginHeatmap">
+        <param name="android-package" value="plugin.google.maps.PluginHeatmap"/>
+      </feature>
       <feature name="PluginTileOverlay">
         <param name="android-package" value="plugin.google.maps.PluginTileOverlay"/>
       </feature>
@@ -207,6 +213,7 @@
     <source-file src="src/android/plugin/google/maps/MyPluginLayout.java" target-dir="src/plugin/google/maps"/>
     <source-file src="src/android/plugin/google/maps/MyPluginInterface.java" target-dir="src/plugin/google/maps"/>
     <source-file src="src/android/plugin/google/maps/PluginCircle.java" target-dir="src/plugin/google/maps"/>
+    <source-file src="src/android/plugin/google/maps/PluginHeatmap.java" target-dir="src/plugin/google/maps"/>
     <source-file src="src/android/plugin/google/maps/PluginGeocoder.java" target-dir="src/plugin/google/maps"/>
     <source-file src="src/android/plugin/google/maps/PluginLocationService.java" target-dir="src/plugin/google/maps"/>
     <source-file src="src/android/plugin/google/maps/PluginGroundOverlay.java" target-dir="src/plugin/google/maps"/>
@@ -508,6 +515,9 @@
       <runs/>
     </js-module>
     <js-module name="PluginCircle" src="src/browser/PluginCircle.js">
+      <runs/>
+    </js-module>
+    <js-module name="PluginHeatmap" src="src/browser/PluginHeatmap.js">
       <runs/>
     </js-module>
     <js-module name="PluginGroundOverlay" src="src/browser/PluginGroundOverlay.js">

--- a/src/android/frameworks/tbxml-android.gradle
+++ b/src/android/frameworks/tbxml-android.gradle
@@ -9,6 +9,7 @@ repositories {
 
 dependencies {
   compile(name:'tbxml-android', ext:'aar')
+  implementation 'com.google.maps.android:android-maps-utils:0.5'
 }
 
 android {

--- a/src/android/plugin/google/maps/MyPlugin.java
+++ b/src/android/plugin/google/maps/MyPlugin.java
@@ -12,6 +12,7 @@ import com.google.android.gms.maps.model.Marker;
 import com.google.android.gms.maps.model.Polygon;
 import com.google.android.gms.maps.model.Polyline;
 import com.google.android.gms.maps.model.TileOverlay;
+import com.google.maps.android.heatmaps.HeatmapTileProvider;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaInterface;
@@ -146,6 +147,15 @@ public class MyPlugin extends CordovaPlugin implements MyPluginInterface {
     }
     return (Circle)pluginMap.objects.get(id);
   }
+
+  protected synchronized HeatmapTileProvider  getHeatmapTileProvider (String id) {
+    if (!pluginMap.objects.containsKey(id)) {
+      //Log.e(TAG, "---> can not find the circle : " + id);
+      return null;
+    }
+    return (HeatmapTileProvider )pluginMap.objects.get(id);
+  }
+
   protected synchronized GroundOverlay getGroundOverlay(String id) {
     if (!pluginMap.objects.containsKey(id)) {
       //Log.e(TAG, "---> can not find the ground overlay : " + id);

--- a/src/android/plugin/google/maps/PluginHeatmap.java
+++ b/src/android/plugin/google/maps/PluginHeatmap.java
@@ -1,0 +1,193 @@
+package plugin.google.maps;
+import com.google.android.gms.maps.model.Circle;
+import com.google.android.gms.maps.model.TileOverlayOptions;
+import com.google.android.gms.maps.model.LatLng;
+import com.google.android.gms.maps.model.LatLngBounds;
+import com.google.android.gms.maps.model.TileOverlay;
+import com.google.maps.android.heatmaps.WeightedLatLng;
+import com.google.maps.android.heatmaps.HeatmapTileProvider;
+import org.apache.cordova.CallbackContext;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import java.util.LinkedList;
+
+public class PluginHeatmap extends MyPlugin implements MyPluginInterface {
+private String heatmapHashCode;
+/**
+   * Create heatmap
+   * @param args
+   * @param callbackContext
+   * @throws JSONException
+   */
+  public void create(final JSONArray args, final CallbackContext callbackContext) throws JSONException {
+    //args = [{data: [[lat_float, long_float], []...]}, "hashCode"]
+    final TileOverlayOptions heatmapOptions = new TileOverlayOptions();
+    // int color;
+    final JSONObject properties = new JSONObject();
+    JSONObject opts = args.getJSONObject(1);
+    final String hashCode = args.getString(2);
+    heatmapHashCode = hashCode;
+
+    JSONArray data = opts.getJSONArray("data");
+    /*if (opts.has("center")) {
+      JSONObject center = opts.getJSONObject("center");
+      heatmapOptions.center(new LatLng(center.getDouble("lat"), center.getDouble("lng")));
+    }
+    if (opts.has("radius")) {
+      heatmapOptions.radius(opts.getDouble("radius"));
+    }
+    if (opts.has("strokeColor")) {
+      color = PluginUtil.parsePluginColor(opts.getJSONArray("strokeColor"));
+      heatmapOptions.strokeColor(color);
+    }
+    if (opts.has("fillColor")) {
+      color = PluginUtil.parsePluginColor(opts.getJSONArray("fillColor"));
+      heatmapOptions.fillColor(color);
+    }
+    if (opts.has("strokeWidth")) {
+      heatmapOptions.strokeWidth((int)(opts.getDouble("strokeWidth") * density));
+    }*/
+    if (opts.has("visible")) {
+      heatmapOptions.visible(opts.getBoolean("visible"));
+    }
+    /*if (opts.has("zIndex")) {
+      heatmapOptions.zIndex(opts.getInt("zIndex"));
+    }
+    if (opts.has("clickable")) {
+      properties.put("isClickable", opts.getBoolean("clickable"));
+    } else {
+      properties.put("isClickable", true);
+    }*/
+    //properties.put("isVisible", heatmapOptions.isVisible());
+    // Since this plugin provide own click detection,
+    // disable default clickable feature.
+    //heatmapOptions.clickable(false);
+cordova.getActivity().runOnUiThread(new Runnable() {
+      @Override
+      public void run() {
+        LinkedList<WeightedLatLng> data_points = new LinkedList<WeightedLatLng>();
+        
+        try {
+          for (int i = 0; i < data.length(); i++) {
+            JSONArray coord = data.getJSONArray(i);
+
+            double lat = coord.getDouble(0);
+            double lon = coord.getDouble(1);
+
+            data_points.add(new WeightedLatLng(new LatLng(lat, lon), 1.));
+          }
+
+          HeatmapTileProvider heatmap = new HeatmapTileProvider.Builder().weightedData(data_points).build();
+          TileOverlay heatmapTileOverlay = map.addTileOverlay(new TileOverlayOptions().tileProvider(heatmap));
+          pluginMap.objects.put("heatmap_" + heatmapHashCode, heatmap);
+          pluginMap.objects.put("heatmapTileOverlay_" + heatmapHashCode, heatmapTileOverlay);
+          pluginMap.objects.put("heatmap_property_" + heatmapHashCode, properties);
+
+          JSONObject result = new JSONObject();
+          
+          result.put("hashCode", hashCode);
+          result.put("__pgmId", "heatmap_" + hashCode);
+          callbackContext.success(result);
+        } catch (JSONException e) {
+          e.printStackTrace();
+          callbackContext.error(e.getMessage() + "");
+        }
+      }
+    });
+}
+/**
+   * set data and refresh heatmap
+   * @param args
+   * @param callbackContext
+   * @throws JSONException
+   */
+  @SuppressWarnings("unused")
+  public void setData(final JSONArray args, final CallbackContext callbackContext) throws JSONException {
+    String id = args.getString(0);
+    
+    final JSONArray data = args.getJSONArray(1);
+    LinkedList<WeightedLatLng> data_points = new LinkedList<WeightedLatLng>();
+  for (int i = 0; i < data.length(); i++) {
+      JSONArray coord = data.getJSONArray(i);
+
+      double lat = coord.getDouble(0);
+      double lon = coord.getDouble(1);
+
+      data_points.add(new WeightedLatLng(new LatLng(lat, lon), 1.));
+    }
+
+    final HeatmapTileProvider heatmap = this.getHeatmapTileProvider(id);
+cordova.getActivity().runOnUiThread(new Runnable() {
+      @Override
+      public void run() {
+        // Recalculate the heatmap bounds
+        heatmap.setWeightedData(data_points);
+        TileOverlay heatmapTileOverlay = (TileOverlay)pluginMap.objects.get("heatmapTileOverlay_" + heatmapHashCode);
+        heatmapTileOverlay.clearTileCache();
+        //String propertyId = "heatmap_bounds_" + heatmapHashCode;
+        //pluginMap.objects.put(propertyId, bounds);
+        callbackContext.success();
+      }
+    });
+  }
+
+/**
+   * set z-index
+   * @param args
+   * @param callbackContext
+   * @throws JSONException
+   */
+  @SuppressWarnings("unused")
+  public void setZIndex(final JSONArray args, final CallbackContext callbackContext) throws JSONException {
+    String id = args.getString(0);
+    float zIndex = (float) args.getDouble(1);
+    this.setFloat("setZIndex", id, zIndex, callbackContext);
+  }
+/**
+   * Set visibility for the object
+   * @param args
+   * @param callbackContext
+   * @throws JSONException
+   */
+  public void setVisible(JSONArray args, CallbackContext callbackContext) throws JSONException {
+    String id = args.getString(0);
+    final boolean isVisible = args.getBoolean(1);
+    final TileOverlay heatmapTileOverlay = this.getTileOverlay(id);
+cordova.getActivity().runOnUiThread(new Runnable() {
+      @Override
+      public void run() {
+        heatmapTileOverlay.setVisible(isVisible);
+      }
+    });
+    String propertyId = "heatmap_property_" + heatmapHashCode;
+    JSONObject properties = (JSONObject)pluginMap.objects.get(propertyId);
+    properties.put("isVisible", isVisible);
+    pluginMap.objects.put(propertyId, properties);
+    callbackContext.success();
+  }
+  /**
+   * Remove the heatmap
+   * @param args
+   * @param callbackContext
+   * @throws JSONException
+   */
+  public void remove(final JSONArray args, final CallbackContext callbackContext) throws JSONException {
+    final String id = args.getString(0);
+    final TileOverlay heatmapTileOverlay = this.getTileOverlay(id);
+    if (heatmapTileOverlay == null) {
+      callbackContext.success();
+      return;
+    }
+    cordova.getActivity().runOnUiThread(new Runnable() {
+      @Override
+      public void run() {
+        heatmapTileOverlay.remove();
+        if (pluginMap.objects != null) {
+          pluginMap.objects.remove(id);
+        }
+        callbackContext.success();
+      }
+    });
+  }
+}

--- a/src/browser/PluginHeatmap.js
+++ b/src/browser/PluginHeatmap.js
@@ -1,0 +1,127 @@
+
+
+
+var utils = require('cordova/utils'),
+  event = require('cordova-plugin-googlemaps.event'),
+  BaseClass = require('cordova-plugin-googlemaps.BaseClass');
+
+function PluginHeatmap(pluginMap) {
+  var self = this;
+  BaseClass.apply(self);
+  Object.defineProperty(self, 'pluginMap', {
+    value: pluginMap,
+    writable: false
+  });
+}
+
+utils.extend(PluginHeatmap, BaseClass);
+
+PluginHeatmap.prototype._create = function(onSuccess, onError, args) {
+  var self = this,
+    map = self.pluginMap.get('map'),
+    heatmapId = 'heatmap_' + args[2],
+    pluginOptions = args[1];
+
+  var heatmapOpts = {
+    'overlayId': heatmapId,
+    'map': map,
+    'data' : pluginOptions.data
+  };
+  
+  if ('zIndex' in pluginOptions) {
+    heatmapOpts.zIndex = pluginOptions.zIndex;
+  }
+  if ('visible' in pluginOptions) {
+    heatmapOpts.visible = pluginOptions.visible;
+  }
+  if ('clickable' in pluginOptions) {
+    heatmapOpts.clickable = pluginOptions.clickable;
+  }
+
+  var heatmap = new google.maps.Heatmap(heatmapOpts);
+  /*circle.addListener('click', function(polyMouseEvt) {
+    self._onCircleEvent.call(self, circle, polyMouseEvt);
+  });*/
+
+  self.pluginMap.objects[heatmapId] = heatmap;
+
+  onSuccess({
+    '__pgmId': heatmapId
+  });
+};
+
+PluginHeatmap.prototype.setData = function(onSuccess, onError, args) {
+  var self = this;
+  var overlayId = args[0];
+  var data = args[1];
+  var heatmap = self.pluginMap.objects[overlayId];
+  if (heatmap) {
+    heatmap.setData(data);
+  }
+  onSuccess();
+};
+
+PluginHeatmap.prototype.setZIndex = function(onSuccess, onError, args) {
+  var self = this;
+  var overlayId = args[0];
+  var zIndex = args[1];
+  var heatmap = self.pluginMap.objects[overlayId];
+  if (heatmap) {
+    heatmap.setOptions({
+      'zIndex': zIndex
+    });
+  }
+  onSuccess();
+};
+
+PluginHeatmap.prototype.setVisible = function(onSuccess, onError, args) {
+  var self = this;
+  var overlayId = args[0];
+  var visible = args[1];
+  var heatmap = self.pluginMap.objects[overlayId];
+  if (heatmap) {
+    heatmap.setVisible(visible === true);
+  }
+  onSuccess();
+};
+
+PluginHeatmap.prototype.setClickable = function(onSuccess, onError, args) {
+  var self = this;
+  var overlayId = args[0];
+  var clickable = args[1];
+  var heatmap = self.pluginMap.objects[overlayId];
+  if (heatmap) {
+    heatmap.setOptions({
+      'clickable': clickable === true
+    });
+  }
+  onSuccess();
+};
+
+PluginHeatmap.prototype.remove = function(onSuccess, onError, args) {
+  var self = this;
+  var overlayId = args[0];
+  var heatmap = self.pluginMap.objects[overlayId];
+  if (heatmap) {
+    google.maps.event.clearInstanceListeners(heatmap);
+    heatmap.remove();
+    circle = undefined;
+    self.pluginMap.objects[overlayId] = undefined;
+    delete self.pluginMap.objects[overlayId];
+  }
+  onSuccess();
+};
+
+PluginHeatmap.prototype._onCircleEvent = function(circle, polyMouseEvt) {
+  var self = this,
+    mapId = self.pluginMap.__pgmId;
+  if (mapId in plugin.google.maps) {
+    plugin.google.maps[mapId]({
+      'evtName': event.HEATMAP_CLICK,
+      'callback': '_onOverlayEvent',
+      'args': [circle.overlayId, new plugin.google.maps.LatLng(polyMouseEvt.latLng.lat(), polyMouseEvt.latLng.lng())]
+    });
+  }
+
+};
+module.exports = PluginHeatmap;

--- a/www/Heatmap.js
+++ b/www/Heatmap.js
@@ -1,0 +1,104 @@
+var utils = require('cordova/utils'),
+  common = require('./Common'),
+  LatLngBounds = require('./LatLngBounds'),
+  Overlay = require('./Overlay');
+
+/*****************************************************************************
+ * Heatmap Class
+ *****************************************************************************/
+var Heatmap = function (map, heatmapOptions, _exec) {
+  Overlay.call(this, map, heatmapOptions, 'Heatmap', _exec);
+
+  var self = this;
+
+  //-----------------------------------------------
+  // Sets event listeners
+  //-----------------------------------------------
+  self.on('clickable_changed', function () {
+    var clickable = self.get('clickable');
+    self.exec.call(self, null, self.errorHandler, self.getPluginName(), 'setClickable', [self.getId(), clickable]);
+  });
+  self.on('data_changed', function () {
+    var data = self.get('data');
+    self.exec.call(self, null, self.errorHandler, self.getPluginName(), 'setData', [self.getId(), data]);
+  });
+  self.on('zIndex_changed', function () {
+    var zIndex = self.get('zIndex');
+    self.exec.call(self, null, self.errorHandler, self.getPluginName(), 'setZIndex', [self.getId(), zIndex]);
+  });
+  self.on('visible_changed', function () {
+    var visible = self.get('visible');
+    self.exec.call(self, null, self.errorHandler, self.getPluginName(), 'setVisible', [self.getId(), visible]);
+  });
+
+};
+
+utils.extend(Heatmap, Overlay);
+
+Heatmap.prototype.getData = function () {
+  return this.get('data');
+};
+Heatmap.prototype.getZIndex = function () {
+  return this.get('zIndex');
+};
+Heatmap.prototype.getVisible = function () {
+  return this.get('visible');
+};
+Heatmap.prototype.getClickable = function () {
+  return this.get('clickable');
+};
+Heatmap.prototype.setVisible = function (visible) {
+  visible = common.parseBoolean(visible);
+  this.set('visible', visible);
+  return this;
+};
+Heatmap.prototype.setClickable = function (clickable) {
+  clickable = common.parseBoolean(clickable);
+  this.set('clickable', clickable);
+  return this;
+};
+Heatmap.prototype.setZIndex = function (zIndex) {
+  this.set('zIndex', zIndex);
+  return this;
+};
+Heatmap.prototype.setData = function (data) {
+  this.set('data', data);
+  return this;
+};
+
+Heatmap.prototype.remove = function (callback) {
+  var self = this;
+  if (self._isRemoved) {
+    if (typeof callback === 'function') {
+      return;
+    } else {
+      return Promise.resolve();
+    }
+  }
+  Object.defineProperty(self, '_isRemoved', {
+    value: true,
+    writable: false
+  });
+  self.trigger(self.__pgmId + '_remove');
+
+  var resolver = function(resolve, reject) {
+    self.exec.call(self,
+      function() {
+        self.destroy();
+        resolve.call(self);
+      },
+      reject.bind(self),
+      self.getPluginName(), 'remove', [self.getId()], {
+        remove: true
+      });
+  };
+
+  if (typeof callback === 'function') {
+    resolver(callback, self.errorHandler);
+  } else {
+    return new Promise(resolver);
+  }
+
+};
+
+module.exports = Heatmap;


### PR DESCRIPTION
I added a new class "Heatmap" that allows drawing of heatmaps using [Google's Heatmap Utility](https://developers.google.com/maps/documentation/android-sdk/utility/heatmap) on Android (no support to iOS).

The classes `Heatmap.js`, `PluginHeatmap.js`, `PluginHeatmap.java` were all implemented and integrated to the main class `Map.js`.

The code works, although probably some functions could've been better implemented (I did this in a hurry).