### PR TITLE
Fix null exception

### DIFF
--- a/src/android/plugin/google/maps/PluginMap.java
+++ b/src/android/plugin/google/maps/PluginMap.java
@@ -725,6 +725,11 @@ public class PluginMap extends MyPlugin implements OnMarkerClickListener,
       @Override
       public void run() {
 
+        if(mapCtrl.mPluginLayout == null || mapDivId == null) {
+            callbackContext.success();
+            return;
+        }
+          
         RectF drawRect = mapCtrl.mPluginLayout.HTMLNodeRectFs.get(mapDivId);
 
         //Log.d(TAG, "--->mapDivId = " + mapDivId + ", drawRect = " + drawRect);


### PR DESCRIPTION
When calling setDiv(null) in the js page, however, map resize event is also happening. This causes null exception.

**Scenario**.
_App setup_
Root page has a map view. When pushing a child view (which also has another map view), I call map.setDiv(null) in the root page willLeave function.

_Steps_
I load my app through deeplinks to view child map. It start load of root page, then automatically push child page. This scenario occasionally encounter this null exception

# Pull request guide

Thank you for considering to improve this cordova-plugin-googlemaps.

When you create a pull request, please make it to **multiple_maps** branch instead of master branch.

Because **the multiple_maps branch is edge version**.

Thank you for your understanding.
