### PR TITLE
fixed flickering and wrong rendering of some dom elements

### DIFF
--- a/www/pluginInit.js
+++ b/www/pluginInit.js
@@ -91,13 +91,13 @@ function pluginInit() {
   cssAdjuster.setAttribute('type', 'text/css');
   cssAdjuster.innerText = [
     'html, body, ._gmaps_cdv_ {',
-    '   background-image: url() !important;',
-    '   background: rgba(0,0,0,0) url() !important;',
+    '   background-image: none !important;',
+    '   background: rgba(0,0,0,0) none !important;',
     '   background-color: rgba(0,0,0,0) !important;',
     '}',
     '._gmaps_cdv_ .nav-decor {',
     '   background-color: rgba(0,0,0,0) !important;',
-    '   background: rgba(0,0,0,0) !important;',
+    '   background: rgba(0,0,0,0) none !important;',
     '   display:none !important;',
     '}',
     '.framework7-root .page-previous {',


### PR DESCRIPTION
Browser was trying to set index.html itself as background image. That invoked a warning: Resource interpreted as Image but transferred with MIME type text/html: "file:///android_asset/www/index.html". For the time of downloading index.html there was a flicker and some elements was not renered properly.