### PR TITLE
[ANDROID] [Fix] Clicking on polyline no longer registering, after a polyline is removed from the map

### DIFF
--- a/src/android/plugin/google/maps/PluginMarker.java
+++ b/src/android/plugin/google/maps/PluginMarker.java
@@ -855,6 +855,9 @@ public class PluginMarker extends MyPlugin implements MyPluginInterface {
     String propertyId = "marker_property_" + id;
     pluginMap.objects.remove(propertyId);
 
+    String imageSizeKey = "marker_imageSize_" + id;
+    pluginMap.objects.remove(imageSizeKey);
+
     cordova.getActivity().runOnUiThread(new Runnable() {
       @Override
       public void run() {

--- a/src/android/plugin/google/maps/PluginPolyline.java
+++ b/src/android/plugin/google/maps/PluginPolyline.java
@@ -160,6 +160,9 @@ public class PluginPolyline extends MyPlugin implements MyPluginInterface  {
     id = "polyline_bounds_" + polylineHashCode;
     pluginMap.objects.remove(id);
 
+    String propertyKey = "polyline_property_" + polylineHashCode;
+    pluginMap.objects.remove(propertyKey);
+
     cordova.getActivity().runOnUiThread(new Runnable() {
       @Override
       public void run() {


### PR DESCRIPTION
"polyline_property" is not removed from the pluginMap.objects list, when calling polyline.remove.
This causes exception in onMapClicked, when looking for the corresponding "polyline_bounds" object (which was already removed) .

Also fix "marker_imageSize" not removed when Marker.remove is called

# Pull request guide

Thank you for considering to improve this cordova-plugin-googlemaps.

When you create a pull request, please make it to **multiple_maps** branch instead of master branch.

Because **the multiple_maps branch is edge version**.

Thank you for your understanding.
