### PR TITLE
[ANDROID] [Feature] - Ability to change clickability of POI

### DIFF
--- a/src/android/plugin/google/maps/PluginMap.java
+++ b/src/android/plugin/google/maps/PluginMap.java
@@ -3179,5 +3179,20 @@ public class PluginMap extends MyPlugin implements OnMarkerClickListener,
     }
   }
 
+  public void setClickablePOI(JSONArray args, final CallbackContext callbackContext)  throws JSONException {
+    final boolean clickable = args.getBoolean(0);
+    activity.runOnUiThread(new Runnable() {
+      @Override
+      public void run() {
+        if (clickable) {
+          map.setOnPoiClickListener(PluginMap.this);
+        } else {
+          map.setOnPoiClickListener(null);
+        }
 
+        callbackContext.success();
+      }
+    });
+  }
+  
 }

--- a/www/Map.js
+++ b/www/Map.js
@@ -1586,4 +1586,15 @@ Map.prototype._onCameraEvent = function(eventName, cameraPosition) {
   }
 };
 
+Map.prototype.setClickablePOI = function(isClickable) {
+  var self = this;
+  isClickable = common.parseBoolean(isClickable);
+  self.set('clickablePOI', isClickable);
+  self.exec.call(self, null, self.errorHandler, this.__pgmId, 'setClickablePOI', [isClickable]);
+  return this;
+};
+Map.prototype.getClickablePOI = function() {
+  return this.get('clickablePOI');
+};
+
 module.exports = Map;

--- a/www/Map.js
+++ b/www/Map.js
@@ -89,6 +89,8 @@ Map.prototype.getMap = function(meta, div, options) {
     args = [meta];
   options = options || {};
 
+  self.set('clickablePOI', true)  // Current POI are clickable by default
+  
   self.set('clickable', options.clickable === false ? false : true);
   self.set('visible', options.visible === false ? false : true);
 


### PR DESCRIPTION
This PR introduce the ability to change whether POI is clickable.

If the developer does not want interactions with POI, currently, the plugin can only hide the POI by setting map styles.
This give the developer more flexibly on how to handle POI on their map.

**Use case**
Sometime tapping on Polyline does not register. This is due to the tap position being near a POI. The POI registers the clicking event instead of the Polyline.

# Pull request guide

Thank you for considering to improve this cordova-plugin-googlemaps.

When you create a pull request, please make it to **multiple_maps** branch instead of master branch.

Because **the multiple_maps branch is edge version**.

Thank you for your understanding.

----

@wf9a5m75
**master** branch has changes that is ahead of **multiple_maps** branch. Creating a PR into **multiple_maps** will also bring these changes.