### PR TITLE
Add "number" parameter to MarkerCluster

### DIFF
--- a/www/MarkerCluster.js
+++ b/www/MarkerCluster.js
@@ -1003,10 +1003,15 @@ Object.defineProperty(MarkerCluster.prototype, '_redraw', {
         }
 
         unionedMarkers.forEach(function (cluster) {
-
+          var number=0;
+          for (var f=0;f<cluster._markerArray.length;f++) {
+            if (typeof cluster._markerArray[f].get('number')!=undefined) {
+              number+=parseInt(cluster._markerArray[f].get('number'));
+            }
+          }
           var icon = self.getClusterIcon(cluster),
             clusterOpts = {
-              'count': cluster.getItemLength(),
+              'count':  (number)? number:cluster.getItemLength(),
               'position': cluster.getBounds().getCenter(),
               '__pgmId': cluster.getId()
             };


### PR DESCRIPTION
When you add markers to  MarkerCluster add a optional "number" parameter to the MarkerOptions (default: number=1). That way, MarkerCluster instead of showing the count of Markers, will show the sum of the "number" field in the Markers.
Very useful when you try to add lots and lots of identifical markes. For instance, if you have 100 markers in the same location, you only have to add one marker with "number=100" instead of adding 100 markers.

# Pull request guide

Thank you for considering to improve this cordova-plugin-googlemaps.

When you create a pull request, please make it to **multiple_maps** branch instead of master branch.

Because **the multiple_maps branch is edge version**.

Thank you for your understanding.
