### PR TITLE
Multiple maps

### DIFF
--- a/src/browser/PluginMarker.js
+++ b/src/browser/PluginMarker.js
@@ -150,7 +150,7 @@ PluginMarker.prototype.__create = function(markerId, pluginOptions, onSuccess, o
         });
       };
       img.onerror = function(error) {
-        console.warn(error.getMessage());
+        console.warn(`Error loading marker`);
         onSuccess(marker, {
           '__pgmId': markerId,
           'width': 20,

--- a/src/browser/PluginMarkerCluster.js
+++ b/src/browser/PluginMarkerCluster.js
@@ -353,7 +353,7 @@ PluginMarkerCluster.prototype.redrawClusters = function(onSuccess, onError, args
                 }
                 self.pluginMarkers[clusterId_markerId] = STATUS.DELETED;
 
-                console.warn(error.getMessage());
+                console.warn(`Error loading marker`);
                 self.deleteMarkers.push(clusterId_markerId);
                 resolve();
               });


### PR DESCRIPTION
When adding a marker, the onerror function should not be calling getMessage() as I believe this is a Java function call. Ideally the message written to the console should include some way to identify the marker that generated the error such as the path, url or Id.