### PR TITLE
Fix #2871 - Resolve blank map when running compiled with latest cordova-android (which uses AGP 4.1.3)

### DIFF
--- a/src/android/plugin/google/maps/CordovaGoogleMaps.java
+++ b/src/android/plugin/google/maps/CordovaGoogleMaps.java
@@ -448,15 +448,13 @@ public class CordovaGoogleMaps extends CordovaPlugin implements ViewTreeObserver
     //------------------------------------------
     JSONObject meta = args.getJSONObject(0);
     String mapId = meta.getString("__pgmId");
-    PluginMap pluginMap = new PluginMap();
-    pluginMap.privateInitialize(mapId, cordova, webView, null);
-    pluginMap.initialize(cordova, webView);
-    pluginMap.mapCtrl = CordovaGoogleMaps.this;
-    pluginMap.self = pluginMap;
 
+    PluginMap pluginMap = new PluginMap();
     PluginEntry pluginEntry = new PluginEntry(mapId, pluginMap);
     pluginManager.addService(pluginEntry);
 
+    pluginMap.mapCtrl = CordovaGoogleMaps.this;
+    pluginMap.self = pluginMap;
     pluginMap.getMap(args, callbackContext);
   }
 

--- a/src/android/plugin/google/maps/CordovaGoogleMaps.java
+++ b/src/android/plugin/google/maps/CordovaGoogleMaps.java
@@ -468,14 +468,12 @@ public class CordovaGoogleMaps extends CordovaPlugin implements ViewTreeObserver
     String mapId = meta.getString("__pgmId");
     Log.d(TAG, "---> mapId = " + mapId);
     PluginStreetViewPanorama pluginStreetView = new PluginStreetViewPanorama();
-    pluginStreetView.privateInitialize(mapId, cordova, webView, null);
-    pluginStreetView.initialize(cordova, webView);
-    pluginStreetView.mapCtrl = CordovaGoogleMaps.this;
-    pluginStreetView.self = pluginStreetView;
-
     PluginEntry pluginEntry = new PluginEntry(mapId, pluginStreetView);
     pluginManager.addService(pluginEntry);
 
+    pluginStreetView.mapCtrl = CordovaGoogleMaps.this;
+    pluginStreetView.self = pluginStreetView;
+    
     pluginStreetView.getPanorama(args, callbackContext);
   }
 

--- a/src/android/plugin/google/maps/PluginMap.java
+++ b/src/android/plugin/google/maps/PluginMap.java
@@ -613,9 +613,6 @@ public class PluginMap extends MyPlugin implements OnMarkerClickListener,
       plugins.put(pluginName, pluginEntry);
       mapCtrl.pluginManager.addService(pluginEntry);
 
-      plugin.privateInitialize(pluginName, cordova, webView, null);
-
-      plugin.initialize(cordova, webView);
       ((MyPluginInterface)plugin).setPluginMap(PluginMap.this);
       MyPlugin myPlugin = (MyPlugin) plugin;
       myPlugin.self = (MyPlugin)plugin;
@@ -666,8 +663,6 @@ public class PluginMap extends MyPlugin implements OnMarkerClickListener,
       pluginMap = PluginMap.this;
       pluginMap.mapCtrl.pluginManager.addService(pluginEntry);
 
-      plugin.privateInitialize(className, cordova, webView, null);
-      plugin.initialize(cordova, webView);
       ((MyPluginInterface)plugin).setPluginMap(PluginMap.this);
       pluginEntry.plugin.execute("create", args, callbackContext);
 


### PR DESCRIPTION
Fix #2871

From AGP 4.1.+ `assert` keyword/statements are enabled by the compile through code rewrite.

Which is causing PluginMap to fail

----

The issue is caused by `PluginMap` being initialised 2 times. The 2nd time it is initialised, `CordovaPlugin.privateInitialize` has `assert` to prevent this.

This PR removes initialising the `PluginMap` in `CordovaGoogleMaps.getMap`, because when it is added to `PluginManager` it will be initialised then.

-----

**NOTE**

Although the relevant code in `PluginManager` and `CordovaPlugin` has not been changed for many years.
The plugin's codebase works for older cordova-android versions because they use older AGP.

In these older versions, `assert` keyword/statement do nothing
