### PR TITLE
KML polystyle outline and fill support for 'true' as node value

### DIFF
--- a/www/KmlLoader.js
+++ b/www/KmlLoader.js
@@ -657,10 +657,10 @@ KmlLoader.prototype.parsePolygonTag = function(params, callback) {
           polygonOptions.fillColor = kmlColorToRGBA(node.value);
           break;
         case 'fill':
-          polygonOptions.fill = node.value === '1';
+          polygonOptions.fill = node.value === '1' || node.value === 'true';
           break;
         case 'outline':
-          polygonOptions.outline = node.value === '1';
+          polygonOptions.outline = node.value === '1' || node.value === 'true';
           break;
         }
       });

--- a/www/KmlLoader.js
+++ b/www/KmlLoader.js
@@ -657,10 +657,10 @@ KmlLoader.prototype.parsePolygonTag = function(params, callback) {
           polygonOptions.fillColor = kmlColorToRGBA(node.value);
           break;
         case 'fill':
-          polygonOptions.fill = node.value === '1' || node.value === 'true';
+          polygonOptions.fill = node.value === '1' || node.value === 'true' || node.value === 1;
           break;
         case 'outline':
-          polygonOptions.outline = node.value === '1' || node.value === 'true';
+          polygonOptions.outline = node.value === '1' || node.value === 'true' || node.value === 1;
           break;
         }
       });


### PR DESCRIPTION
Fixing this issue:

https://github.com/mapsplugin/cordova-plugin-googlemaps/issues/2875