### PR TITLE
multiple_maps - iOS: Fix misplaced or white splash screen

### DIFF
--- a/src/ios/GoogleMaps/CordovaGoogleMaps.m
+++ b/src/ios/GoogleMaps/CordovaGoogleMaps.m
@@ -12,10 +12,11 @@
 
 - (void)pluginInitialize
 {
-
-  self.webView.backgroundColor = [UIColor clearColor];
-  self.webView.opaque = NO;
-  [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(pageDidLoad) name:CDVPageDidLoadNotification object:nil];
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(pageDidLoad)
+                                               name:CDVPageDidLoadNotification
+                                             object:nil];
+  
   dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
     self.executeQueue =  [NSOperationQueue new];
     self.executeQueue.maxConcurrentOperationCount = 10;
@@ -53,7 +54,8 @@
 
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(didRotate:)
-                                                 name:UIDeviceOrientationDidChangeNotification object:nil];
+                                                 name:UIDeviceOrientationDidChangeNotification
+                                               object:nil];
 
     [[UIDevice currentDevice] beginGeneratingDeviceOrientationNotifications];
 
@@ -68,22 +70,34 @@
   // Plugin initialization
   //-------------------------------
   self.viewPlugins = [[NSMutableDictionary alloc] init];
-
+  
+  // Initialize the plugin layer
+  // This removes the webView from the view hierarchy and adds it to the plugin layer
   self.pluginLayer = [[MyPluginLayer alloc] initWithWebView:self.webView];
-  self.pluginLayer.backgroundColor = [UIColor whiteColor];
+  self.pluginLayer.backgroundColor = [UIColor clearColor]; // Set to clear to avoid white screen
   self.pluginLayer.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-
-
-  NSArray *subViews = self.viewController.view.subviews;
-  //NSLog(@"--->subViews count=%lu", subViews.count);
-  UIView *view;
-  for (int i = 0; i < [subViews count]; i++) {
-    view = [subViews objectAtIndex:i];
-    //NSLog(@"--->remove i=%d class=%@", i, view.class);
-    [view removeFromSuperview];
-    [self.pluginLayer addSubview: view];
-  }
+  self.pluginLayer.userInteractionEnabled = NO; // Ensure the plugin layer does not intercept touch events
+  
+  // Add the plugin layer to the back, so it is not disturbing the splash screen
+  // When the plugin layer is in the back, the plugin layer and the containing webView is not clickable
   [self.viewController.view addSubview:self.pluginLayer];
+  [self.viewController.view sendSubviewToBack:self.pluginLayer];
+  
+  // Move the plugin layer, after the splash screen is dismissed, to the front
+  // so the plugin layer and the webView is clickable
+  // Read the SplashScreenDelay value from config.xml
+  NSString *splashScreenDelayString = [((CDVViewController *)self.viewController).settings objectForKey:@"splashscreendelay"];
+  // If no SplashScreenDelay ist set, set no delay. Cordova states, that the default value for
+  // iOS is 3000ms, but it seems, when testing it, that the splash screen is hidden, right after the initialization is complete
+  double splashScreenDelay = splashScreenDelayString ? [splashScreenDelayString doubleValue] : 0;
+  // Add some extra delay, to let the splash screen fade out, otherwise it will be hidden, without the animation
+  // This can have the side effect, that the app is not clickable for a short period of time, after the splash screen is dismissed
+  splashScreenDelay += 2000;
+  
+  // Move the plugin layer to the front
+  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(splashScreenDelay * NSEC_PER_MSEC)), dispatch_get_main_queue(), ^{
+    [self.viewController.view bringSubviewToFront:self.pluginLayer];
+  });
 }
 - (void) didRotate:(id)sender
 {


### PR DESCRIPTION
The splash screen on iOS was misplaced or was not appearing. To fix this, the views will not be removed anymore from the view hierarchy and the plugin layer will be send only to the front, when the splash screen is dismissed.