### PR TITLE
multiple_maps - Android: Fix minSdkVersion 19 cannot be smaller than version 21

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -155,7 +155,7 @@
       <preference name="BackgroundColor" value="0"/>
 
       <!-- for this plugin -->
-      <preference name="android-minSdkVersion" value="19"/>
+      <preference name="android-minSdkVersion" value="21"/>
     </config-file>
 
     <config-file target="res/xml/config.xml" parent="/*">


### PR DESCRIPTION
When you make a fresh Cordova app, add this plugin and build it, there will be the error:

```
.../hello/platforms/android/app/src/main/AndroidManifest.xml Error:
        uses-sdk:minSdkVersion 19 cannot be smaller than version 21 declared in library [androidx.core:core-splashscreen:1.0.0] .../.gradle/caches/transforms-4/34c2c9227e2d15c94d4f3d9edef35ec8/transformed/jetified-core-splashscreen-1.0.0/AndroidManifest.xml as the library might be using APIs not available in 19
        Suggestion: use a compatible library with a minSdk of at most 19,
                or increase this project's minSdk version to at least 21,
                or use tools:overrideLibrary="androidx.core.splashscreen" to force usage (may lead to runtime failures)

See https://developer.android.com/r/studio-ui/build/manifest-merger for more information about the manifest merger.
```
this is fixed, by setting minSdk to 21 in plugin.xml