### PR TITLE
multiple_maps - Android: Fix: Invalid <color> for given resource value.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -152,7 +152,6 @@
     <config-file target="config.xml" parent="/*">
       <!-- for Crosswalk -->
       <preference name="xwalkZOrderOnTop" value="true"/>
-      <preference name="BackgroundColor" value="0"/>
 
       <!-- for this plugin -->
       <preference name="android-minSdkVersion" value="19"/>


### PR DESCRIPTION
For the deprecated Crosswalk WebView, the preference key "BackgroundColor" was wrongly set with "0". It would have to be set with "#000000", but this would also set the splashscreen backround color to black. So the preference is removed.