### PR TITLE
multiple_maps - Android: Remove obsolete repository jcenter

### DIFF
--- a/src/android/frameworks/tbxml-android.gradle
+++ b/src/android/frameworks/tbxml-android.gradle
@@ -1,7 +1,6 @@
 repositories {
   maven { url 'https://maven.google.com' }
   mavenCentral()
-  jcenter()
   def libsDirPath = System.getProperty("user.dir")
   flatDir{
     dirs 'src/main/libs', 'libs', "${libsDirPath}/libs"


### PR DESCRIPTION
- JCenter sunset was on August 15th, 2024. mavenCentral will be used instead.
- The appeareance of jcenter as a repository, produced the gradle warning `Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.`